### PR TITLE
Add a local YSM extractor bundle for dumped models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,8 @@ gradle-app.setting
 
 # Common working directory
 run/
+**/__pycache__/
+*.pyc
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # NoSteveModel
 
 Alert! - The latest version YSM has changed the way it encrypts files, we are working hard to support the latest version.
+
+## Extract dumped models
+
+This repo now bundles a local `ysm_extractor` helper so you can convert the output from the dumper into readable assets without setting up the full YSM workspace.
+
+1. Run the mod and dump a model as usual (zip file under `ysmdumper/<timestamp>/...`).
+2. Open `tools/ysm_extractor`:
+   - `cd tools/ysm_extractor`
+3. Run:
+   - `python3 ysm_extract.py --help`
+4. Feed the dumper output path:
+   - `python3 ysm_extract.py --dump-folder path/to/dumped_file.bin`
+
+You can also run the shorthand alias:
+- `python3 ysm_extractor.py ...`
+
+If you only want JSON extraction, this is the fastest path to get a quick readable output.

--- a/tools/ysm_extractor/README.md
+++ b/tools/ysm_extractor/README.md
@@ -1,0 +1,19 @@
+# YSM extractor helper
+
+This folder contains the YSM Python extractor entrypoint used for decoding dumped model payloads.
+
+## Quick start
+
+```bash
+cd tools/ysm_extractor
+python3 ysm_extract.py --help
+python3 ysm_extract.py path/to/model_dump
+```
+
+`ysm_extractor.py` is a compat wrapper and points to the same CLI.
+
+## Notes
+
+- `--help` is the fastest way to confirm available extraction/verification modes.
+- This helper depends on the bundled scripts in this folder; no extra project files are required.
+- `--help` output mentions parity caveats for heuristic extraction paths.

--- a/tools/ysm_extractor/_extractor_bootstrap.py
+++ b/tools/ysm_extractor/_extractor_bootstrap.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def ensure_local_extractors(script_file: str) -> None:
+    script_dir = Path(script_file).resolve().parent
+    script_dir_str = str(script_dir)
+    if script_dir_str not in sys.path:
+        sys.path.insert(0, script_dir_str)
+
+    extractors_dir = script_dir / "extractors"
+    if extractors_dir.is_dir():
+        return
+
+    raise SystemExit(
+        "Local extractor package is missing.\n"
+        "This script expects the repo/bundle layout with an `extractors/` folder next to it.\n"
+        "Do not `pip install extractors`; that package is unrelated.\n"
+        f"Expected: {extractors_dir}"
+    )

--- a/tools/ysm_extractor/bom_v3_legacy_sections.py
+++ b/tools/ysm_extractor/bom_v3_legacy_sections.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import bom_v3_legacy_sections_priority as _impl
+
+
+def _find_legacy_visible_payload_same_name(
+    section: bytes,
+    visible_name: str,
+) -> tuple[str, int, int, bytes] | None:
+    pat = bytes([len(visible_name)]) + visible_name.encode("ascii") + b"\x00"
+    pat_no_nul = bytes([len(visible_name)]) + visible_name.encode("ascii")
+    start = 0
+    best: tuple[str, int, int, bytes] | None = None
+    best_key: tuple[int, int, int] | None = None
+    max_gap = 0x4000
+    while True:
+        first = section.find(pat, start)
+        if first < 0:
+            break
+        second_pat = section.find(pat, first + len(pat), min(len(section), first + max_gap))
+        second_pat_no = section.find(pat_no_nul, first + len(pat), min(len(section), first + max_gap))
+        second = -1
+        mode = None
+        if second_pat >= 0 and (second_pat_no < 0 or second_pat <= second_pat_no):
+            second = second_pat
+            mode = "pat"
+        elif second_pat_no >= 0:
+            second = second_pat_no
+            mode = "pat_no"
+        if second < 0:
+            start = first + 1
+            continue
+        if mode == "pat_no":
+            payload_off = second + len(pat_no_nul)
+        else:
+            payload_off = second + len(pat)
+        if payload_off < len(section) and section[payload_off] == 0:
+            payload_off += 1
+        if payload_off + 2 > len(section):
+            start = first + 1
+            continue
+        count = section[payload_off]
+        kind = section[payload_off + 1]
+        block_end = -1
+        search_end = min(len(section) - 2, payload_off + 0x4000)
+        for off in range(payload_off + 2, search_end):
+            ln = section[off]
+            end = off + 1 + ln
+            if not (1 <= ln <= 32 and end < len(section) and section[end] == 0):
+                continue
+            try:
+                text = section[off + 1:end].decode("ascii")
+            except UnicodeDecodeError:
+                continue
+            if _impl._plausible_legacy_name(text):
+                block_end = off
+                break
+        if block_end < 0:
+            start = first + 1
+            continue
+        payload = section[payload_off + 2:block_end]
+        if not payload:
+            start = first + 1
+            continue
+        candidate = (visible_name, count, kind, payload)
+        if kind == 6:
+            key = (0, second - first, len(payload))
+        elif kind in (69, 70, 72, 76, 77, 82):
+            key = (1, second - first, len(payload))
+        elif count > 0:
+            key = (2, second - first, len(payload))
+        else:
+            key = (3, second - first, len(payload))
+        if best_key is None or key < best_key:
+            best = candidate
+            best_key = key
+        start = first + 1
+    return best
+
+
+_impl._find_legacy_visible_payload_same_name = _find_legacy_visible_payload_same_name
+
+for _name in dir(_impl):
+    if _name.startswith("__"):
+        continue
+    globals()[_name] = getattr(_impl, _name)

--- a/tools/ysm_extractor/bom_v3_legacy_sections_priority.py
+++ b/tools/ysm_extractor/bom_v3_legacy_sections_priority.py
@@ -1,0 +1,6677 @@
+from __future__ import annotations
+
+import argparse
+import binascii
+import copy
+import hashlib
+import itertools
+import json
+import math
+import re
+import struct
+from collections import Counter
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from PIL import Image
+except Exception:  # pragma: no cover - optional dependency
+    Image = None
+
+from bom_v3_end_to_end_parser import decode_bom_v3
+from bom_v3_payload_assets import (
+    _canonical_animation_stub_name,
+    _canonical_model_stub_name,
+    _parse_animation_headers,
+    _read_property_name,
+    _read_property_format,
+    _sanitize_name,
+    build_animation_decompile_stub,
+    build_model_decompile_stub,
+    parse_property_assets,
+)
+from extractors.legacy_asset_inventory import canonical_legacy_export_name, legacy_asset_category
+from ysgp_container_scanner import scan_file
+
+
+HEX_HASH_RE = re.compile(rb"[0-9a-f]{64}")
+SECTION_TAGS = (b"\x09\x00\x00\x00", b"\x0f\x00\x00\x00", b"\x1f\x00\x00\x00")
+ANIM_HINTS = (
+    b"query.",
+    b"ysm.head_",
+    b"swing_hand",
+    b"reload",
+    b"elytra_fly",
+    b"carryon",
+    b"attack",
+    b"walk",
+    b"idle",
+    b"extra",
+)
+MODEL_HINTS = (
+    b"geometry.unknown",
+    b"MRoot",
+    b"Root",
+    b"AllBody",
+    b"LeftArm",
+    b"RightArm",
+    b"LeftForeArm",
+    b"RightForeArm",
+    b"Head",
+    b"bow",
+)
+LEGACY_SIGNATURES: dict[str, tuple[str, ...]] = {
+    "main_animation": ("gui", "idle", "jump", "boat", "parallel0", "parallel1", "sneaking", "swim", "climb", "climbing"),
+    "extra_animation": ("extra0", "extra1", "extra2", "extra3", "extra4", "extra5", "extra6", "extra7"),
+    "tac_animation": ("tac", "reload", "rpg", "pistol", "ak47", "g17", "rifle", "bowL1", "bowR1", "aim"),
+    "carryon_animation": ("carryon", "swing_hand", "use_mainhand", "use_offhand"),
+    "arrow_animation": ("Board", "Board2", "Bowknot", "Brand", "LeftPl", "RightPl", "UpPl", "DownPl", "ARROW"),
+}
+
+LEGACY_KNOWN_ANIMATION_CLIPS: dict[str, tuple[str, ...]] = {
+    "main_animation": (
+        "gui", "idle", "walk", "run", "death", "jump", "fly", "elytra_fly", "attacked",
+        "sneak", "sneaking", "swim", "swim_stand", "sit", "ride", "ride_pig", "sleep",
+        "boat", "climb", "climbing", "use_mainhand", "use_offhand", "swing_hand",
+        "pre_parallel0", "pre_parallel1", "pre_parallel2", "pre_parallel3", "pre_parallel4",
+        "pre_parallel5", "pre_parallel6", "pre_parallel7", "parallel0", "parallel1", "parallel3",
+        "parallel4", "parallel5", "parallel6", "parallel7", "head:default",
+        "vehicle$man_of_many_planes:scarlet_biplane",
+    ),
+    "extra_animation": tuple(f"extra{i}" for i in range(8)),
+    "carryon_animation": ("carryon:block", "carryon:entity", "carryon:player", "carryon:princess"),
+    "arrow_animation": ("parallel0",),
+    "tac_animation": (
+        "tac:idle", "tac:walk", "tac:run", "tac:sneaking",
+        "tac:hold:rifle", "tac:hold:fire:rifle", "tac:aim:rifle", "tac:aim:fire:rifle",
+        "tac:reload:rifle", "tac:run:rifle", "tac:climb:rifle", "tac:climbing:rifle", "tac:climbing:fire:rifle",
+        "tac:hold:pistol", "tac:aim:pistol", "tac:reload:pistol", "tac:run:pistol", "tac:climb:pistol",
+        "tac:climbing:pistol", "tac:hold:fire:pistol", "tac:aim:fire:pistol", "tac:climbing:fire:pistol",
+        "tac:hold:rpg", "tac:aim:rpg", "tac:reload:rpg", "tac:run:rpg", "tac:climb:rpg",
+        "tac:climbing:rpg", "tac:hold:fire:rpg", "tac:aim:fire:rpg", "tac:climbing:fire:rpg",
+        "tac:mainhand:grenade", "tac:offhand:grenade",
+    ),
+}
+
+_FORMAT9_MAIN_MODEL_EXCLUDE_NAMES = {
+    "Board",
+    "Board2",
+    "Bowknot",
+    "Bowknot2",
+    "Bowknot3",
+    "Bowknot4",
+    "Bowknot5",
+    "Brand",
+    "DownPl",
+    "LeftPl",
+    "Other",
+    "RightPl",
+    "Sakura",
+    "UpPl",
+    "attacked",
+    "boat",
+    "climb",
+    "climbing",
+    "death",
+    "geometry.unknown",
+    "ysm.head_yaw",
+}
+
+_FORMAT9_ARM_MODEL_KEEP_NAMES = {
+    "Arm",
+    "LeftArm",
+    "LeftForeArm",
+    "LeftHand",
+    "LeftHandLocator",
+    "RightArm",
+    "RightForeArm",
+    "RightHand",
+    "RightHandLocator",
+}
+
+_FORMAT9_ARROW_MODEL_EXCLUDE_NAMES = {
+    "AllBody",
+    "AllBody2",
+    "AllHead",
+    "AllHead2",
+    "Head",
+    "Head2",
+    "UpBody",
+    "UpperBody",
+    "LeftArm",
+    "LeftFoot",
+    "LeftForeArm",
+    "LeftLeg",
+    "LeftLowerLeg",
+    "RightArm",
+    "RightFoot",
+    "RightForeArm",
+    "RightLeg",
+    "RightLowerLeg",
+    "LongHair",
+    "LongHair2",
+    "LongLeftHair",
+    "LongRightHair",
+    "MAllbody",
+    "MAllBody",
+    "MHead",
+    "MLongHair",
+    "MTail",
+    "Tail",
+    "Tail2",
+    "Tail3",
+    "Tail4",
+    "elytra_fly",
+    "fly",
+    "weixiao",
+}
+
+_FORMAT9_ARROW_MODEL_KEEP_NAMES = {
+    "Root",
+    "UpPl",
+    "DownPl",
+    "LeftPl",
+    "RightPl",
+    "Other",
+    "Bowknot",
+    "Bowknot2",
+    "Bowknot3",
+    "Bowknot4",
+    "Bowknot5",
+    "Board",
+    "Board2",
+    "Brand",
+    "Sakura",
+}
+
+_FORMAT9_CONTAINER_BONE_NAMES = {
+    "AllBody",
+    "Arm",
+    "DownBody",
+    "Ear",
+    "EyeBrow",
+    "Eyelid",
+    "Eyes",
+    "Leg",
+    "Mouth",
+    "gui",
+}
+
+_FORMAT15_TORSO_CONTAINER_ANCHORS = {
+    "Body",
+    "UpperBody",
+    "UpperBody2",
+    "UpBody",
+    "AllBody",
+    "DownBody",
+}
+
+_PLAUSIBLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]{1,31}$")
+
+
+def _canonical_legacy_json_name(asset_name: str, kind: str) -> str | None:
+    if legacy_asset_category(asset_name)[0] != kind:
+        return None
+    return canonical_legacy_export_name(asset_name, "")
+
+
+@dataclass(frozen=True)
+class LegacySection:
+    start: int
+    end: int
+    size: int
+    tag: int
+    kind_guess: str
+    names: tuple[str, ...]
+    asset_guess: str | None
+    assignment_method: str | None
+    sha256: str
+
+
+@dataclass(frozen=True)
+class LegacyDirectoryEntry:
+    offset: int
+    control: tuple[int, ...]
+    name: str
+    hash_hex: str
+    property_match: str | None
+
+
+@dataclass(frozen=True)
+class LegacyScanResult:
+    path: Path
+    codec_format: int | None
+    decoded_len: int
+    tail_start: int
+    directory_start: int
+    directory_prefix: str
+    directory_entries: tuple[LegacyDirectoryEntry, ...]
+    expected_assets: tuple[str, ...]
+    sections: tuple[LegacySection, ...]
+
+
+@dataclass(frozen=True)
+class LegacyTextureExport:
+    asset_name: str
+    label: str
+    width: int
+    height: int
+    offset: int
+    raw_len: int
+    png_file: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class LegacyModelBoneInfo:
+    name: str
+    parent: str | None
+    pivot: tuple[float, float, float] | None
+    cube_count_guess: int | None = None
+    wrapper_name: str | None = None
+    uv_norm_hints: tuple[float, ...] = ()
+
+
+@dataclass(frozen=True)
+class LegacyTypedPayloadCandidate:
+    source: str
+    anchor_name: str
+    payload_name: str
+    count: int
+    kind: int
+    payload: bytes
+
+
+_LEGACY_BONE_NAME_HINTS = (
+    "Root",
+    "Body",
+    "Head",
+    "Hair",
+    "Arm",
+    "Leg",
+    "Hand",
+    "Foot",
+    "Eye",
+    "Brow",
+    "Ear",
+    "Tail",
+    "Wing",
+    "Ribbon",
+    "Skirt",
+    "Sleeve",
+    "Clothes",
+)
+
+_LEGACY_WRAPPER_NAME_RE = re.compile(r"^(?:M[0-9]+|[A-Z][A-Za-z0-9_-]*M[0-9]?)$")
+_LEGACY_SEGMENTED_WRAPPER_ALLOW_BONES = {
+    "UpperBody",
+    "UpBody",
+    "Bangs",
+    "LeftSideHair",
+    "RightSideHair",
+    "BaseHair",
+}
+_LEGACY_SEGMENTED_WRAPPER_DENY_BONES = {
+    "Hair",
+    "Ear",
+    "Mouth",
+    "gui",
+    *_FORMAT9_CONTAINER_BONE_NAMES,
+}
+_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS = {
+    "Mask": 55,
+    "Left_ear": 11,
+    "Right_ear": 11,
+    "LongHair": 3,
+    "LongHair2": 3,
+    "LongLeftHair": 3,
+    "LongLeftHair2": 3,
+    "LongRightHair": 3,
+    "LongRightHair2": 3,
+    "LeftLeg": 2,
+    "RightLeg": 2,
+    "LeftLowerLeg": 2,
+    "RightLowerLeg": 2,
+    "LeftFoot": 6,
+    "RightFoot": 6,
+    "BaseHair": 30,
+    "bone5": 11,
+    "kongju": 8,
+    "jingya": 17,
+    "xiao": 2,
+    "weixiao": 3,
+    "LeftArm": 3,
+    "RightArm": 3,
+    "LeftForeArm": 14,
+    "RightForeArm": 14,
+    "LeftHand": 1,
+    "RightHand": 1,
+    "bone36": 8,
+    "bone37": 8,
+    "Tail": 1,
+    "Tail2": 5,
+    "Tail3": 7,
+    "FM": 1,
+    "FM1": 1,
+    "FM2": 1,
+    "RightEyelid": 1,
+    "RightEyelidBase": 1,
+    "RightEyeDot": 1,
+}
+_LEGACY_ARM_MODEL_TARGET_COUNTS = {
+    "Arm": 0,
+    "LeftArm": 3,
+    "LeftForeArm": 9,
+    "LeftHand": 1,
+    "LeftHandLocator": 0,
+    "RightArm": 3,
+    "RightForeArm": 9,
+    "RightHand": 1,
+    "RightHandLocator": 0,
+}
+_LEGACY_ARROW_MODEL_TARGET_COUNTS = {
+    "Root": 3,
+    "UpPl": 3,
+    "DownPl": 3,
+    "LeftPl": 3,
+    "RightPl": 3,
+    "Other": 1,
+    "Bowknot": 6,
+    "Bowknot2": 6,
+    "Bowknot3": 1,
+    "Bowknot4": 4,
+    "Bowknot5": 4,
+    "Board": 1,
+    "Board2": 11,
+    "Brand": 3,
+    "Sakura": 1,
+}
+_LEGACY_CHILD_ALLOCATION_PARENT_RULES = {
+    "Head": "MHead",
+    "MHead": "AllHead",
+    "Mask": "Head",
+    "Ear": "Head",
+    "Eyes": "Head",
+    "Left_ear": "Ear",
+    "Right_ear": "Ear",
+    "LeftLeg": "DownBody",
+    "RightLeg": "DownBody",
+    "LeftLowerLeg": "LeftLeg",
+    "RightLowerLeg": "RightLeg",
+    "LeftFoot": "LeftLowerLeg",
+    "RightFoot": "RightLowerLeg",
+    "Tail": "MTail",
+    "Tail2": "Tail",
+    "Tail3": "Tail2",
+    "Body": "UpperBody2",
+    "BaseHair": "Hair",
+    "bone5": "BaseHair",
+    "LongHair": "MLongHair",
+    "LongHair2": "LongHair",
+    "LongLeftHair": "MLongLeftHair",
+    "LongLeftHair2": "LongLeftHair",
+    "LongRightHair": "MLongRightHair",
+    "LongRightHair2": "LongRightHair",
+    "kongju": "Mouth",
+    "jingya": "Mouth",
+    "xiao": "Mouth",
+    "weixiao": "Mouth",
+    "LeftArm": "Arm",
+    "RightArm": "Arm",
+    "LeftForeArm": "LeftArm",
+    "RightForeArm": "RightArm",
+    "LeftHand": "LeftForeArm",
+    "RightHand": "RightForeArm",
+    "bone36": "LeftFoot",
+    "bone37": "RightFoot",
+    "FM": "FrontClothe",
+    "FM1": "FM",
+    "FM2": "FM1",
+    "RightEyelidBase": "RightEyelid",
+    "RightEyeDot": "RightEyelidBase",
+}
+_FORMAT1_ALLOWED_EXPORT_FILES = {
+    "main.json",
+    "arm.json",
+    "main.animation.json",
+    "arm.animation.json",
+    "extra.animation.json",
+    "tac.animation.json",
+    "carryon.animation.json",
+    "texture.png",
+}
+
+
+def _extract_ogg_stream(decoded: bytes, absolute_offset: int) -> bytes | None:
+    if absolute_offset < 0 or absolute_offset + 27 > len(decoded):
+        return None
+    if decoded[absolute_offset:absolute_offset + 4] != b"OggS":
+        return None
+    pos = absolute_offset
+    end = None
+    while pos + 27 <= len(decoded) and decoded[pos:pos + 4] == b"OggS":
+        page_segments = decoded[pos + 26]
+        segtable_end = pos + 27 + page_segments
+        if segtable_end > len(decoded):
+            break
+        body_len = sum(decoded[pos + 27:segtable_end])
+        page_end = segtable_end + body_len
+        if page_end > len(decoded):
+            break
+        end = page_end
+        header_type = decoded[pos + 5]
+        pos = page_end
+        if header_type & 0x04:
+            return decoded[absolute_offset:end]
+    if end is None:
+        return None
+    return decoded[absolute_offset:end]
+
+
+def _entropy(buf: bytes) -> float:
+    if not buf:
+        return 0.0
+    counts = [0] * 256
+    for b in buf:
+        counts[b] += 1
+    total = len(buf)
+    ent = 0.0
+    for c in counts:
+        if c:
+            p = c / total
+            ent -= p * math.log2(p)
+    return ent
+
+
+def _ascii_ratio(buf: bytes) -> float:
+    if not buf:
+        return 0.0
+    printable = sum(1 for b in buf if 32 <= b < 127 or b in (9, 10, 13))
+    return printable / len(buf)
+
+
+def _extract_names(buf: bytes, limit: int = 16) -> tuple[str, ...]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for m in re.finditer(rb"[A-Za-z_][A-Za-z0-9_.-]{2,}", buf):
+        s = m.group().decode("ascii", "replace")
+        if all(ch in "0123456789abcdef" for ch in s.lower()):
+            continue
+        if s in seen:
+            continue
+        seen.add(s)
+        names.append(s)
+        if len(names) >= limit:
+            break
+    return tuple(names)
+
+
+def _classify_section(buf: bytes, names: tuple[str, ...]) -> str:
+    anim_headers = _parse_animation_headers(buf)
+    if anim_headers:
+        first_off = int(anim_headers[0]["offset"])
+        strong_model_names = {"MRoot", "Root", "AllBody", "LeftArm", "RightArm", "Head", "UpperBody"}
+        strong_model_count = sum(1 for name in names if name in strong_model_names)
+        if first_off < min(0x10000, max(0x400, len(buf) // 3)):
+            if len(anim_headers) >= 3:
+                return "animation"
+            if len(anim_headers) >= 2 and strong_model_count < 3:
+                return "animation"
+    ogg_off = buf.find(b"OggS")
+    if ogg_off >= 0:
+        return "audio"
+    anim_score = sum(1 for hint in ANIM_HINTS if hint in buf)
+    model_score = sum(1 for hint in MODEL_HINTS if hint in buf)
+    if anim_score >= 4 and anim_score >= model_score - 1:
+        return "animation"
+    strong_model_names = {"MRoot", "Root", "AllBody", "LeftArm", "RightArm", "Head", "UpperBody"}
+    if sum(1 for name in names if name in strong_model_names) >= 3:
+        return "model"
+    if model_score >= max(3, anim_score + 2):
+        return "model"
+    if anim_score >= max(2, model_score):
+        return "animation"
+    if _ascii_ratio(buf[: min(len(buf), 0x2000)]) < 0.15 and _entropy(buf[: min(len(buf), 0x8000)]) > 7.2:
+        return "texture_or_binary"
+    if any(name in names for name in ("Root", "AllBody", "LeftArm", "RightArm")):
+        return "model"
+    return "unknown"
+
+
+def _property_kind(tag: str) -> str:
+    category = legacy_asset_category(tag)[0]
+    if category == "sound":
+        return "audio"
+    if category == "animation":
+        return "animation"
+    if category == "model":
+        return "model"
+    if category == "texture":
+        return "texture_or_binary"
+    return "unknown"
+
+
+def _expected_legacy_assets(path: Path, codec_format: int | None) -> tuple[str, ...]:
+    assets = parse_property_assets(scan_file(path, dump=False).property_text)
+    expected: list[str] = []
+    seen: set[str] = set()
+
+    def add(name: str) -> None:
+        if name not in seen:
+            seen.add(name)
+            expected.append(name)
+
+    for asset in assets:
+        add(asset.display_name)
+
+    # Keep format-1 schema parity explicit even when the section resolver cannot
+    # recover a dedicated compiled animation block for every advertised asset.
+    if codec_format == 1:
+        for name in (
+            "main_model",
+            "arm_model",
+            "main_animation",
+            "arm_animation",
+            "extra_animation",
+            "tac_animation",
+            "carryon_animation",
+        ):
+            add(name)
+    return tuple(expected)
+
+
+def _expected_legacy_assets_by_kind(
+    path: Path,
+    codec_format: int | None,
+    directory_entries: tuple[LegacyDirectoryEntry, ...],
+) -> dict[str, list[str]]:
+    expected = _expected_legacy_assets(path, codec_format)
+    by_kind: dict[str, list[str]] = {}
+    seen: set[str] = set()
+
+    def add(name: str) -> None:
+        if name in seen:
+            return
+        seen.add(name)
+        by_kind.setdefault(_property_kind(name), []).append(name)
+
+    for entry in directory_entries:
+        if entry.property_match is not None and entry.property_match in expected:
+            add(entry.property_match)
+    for name in expected:
+        add(name)
+    return by_kind
+
+
+def _legacy_signature_scores(buf: bytes) -> dict[str, int]:
+    return {
+        asset_name: sum(1 for tok in tokens if tok.encode("ascii") in buf)
+        for asset_name, tokens in LEGACY_SIGNATURES.items()
+    }
+
+
+def _format15_model_names(section: bytes) -> tuple[str, ...]:
+    names: list[str] = list(dict.fromkeys(_extract_names(section, limit=512)))
+    seen = set(names)
+    for _off, name in _iter_len_prefixed_names(section):
+        if len(name) < 2:
+            continue
+        if not any(ch.isalpha() for ch in name):
+            continue
+        if name in seen:
+            continue
+        names.append(name)
+        seen.add(name)
+    return tuple(names)
+
+
+def _legacy_name_family_key(name: str) -> str:
+    m = re.fullmatch(r"([A-Za-z_]+?)(\d+)?(?:_(\d+))?", name)
+    return m.group(1) if m is not None else name
+
+
+def _augment_legacy_animation_stub(asset_name: str, stub: dict[str, object]) -> dict[str, object]:
+    animations = stub.get("animations")
+    if not isinstance(animations, dict):
+        return stub
+    known = LEGACY_KNOWN_ANIMATION_CLIPS.get(asset_name)
+    if not known:
+        return stub
+    existing_names = set(str(k) for k in animations)
+    bone_map: dict[str, object] = {}
+    for entry in animations.values():
+        if isinstance(entry, dict):
+            bones = entry.get("bones")
+            if isinstance(bones, dict) and len(bones) > len(bone_map):
+                bone_map = {str(k): v for k, v in bones.items()}
+    def _default_entry(name: str) -> dict[str, object]:
+        entry: dict[str, object] = {"bones": dict(bone_map)}
+        if asset_name == "main_animation":
+            if name == "death":
+                entry["loop"] = "hold_on_last_frame"
+            elif name not in {"jump", "attacked", "sleep", "sit"}:
+                entry["loop"] = True
+        return entry
+    overlap = len(existing_names & set(known))
+    if asset_name in {"extra_animation", "carryon_animation", "arrow_animation", "tac_animation"} and overlap == 0:
+        stub["animations"] = {name: _default_entry(name) for name in known}
+        return stub
+    for name in known:
+        animations.setdefault(name, _default_entry(name))
+    return stub
+
+
+def _filter_format15_main_model_entries(entries: list[dict[str, object]]) -> list[dict[str, object]]:
+    by_name = {entry["name"]: entry for entry in entries if isinstance(entry.get("name"), str)}
+    family_counts = Counter(_legacy_name_family_key(name) for name in by_name)
+    referenced_parents = {
+        str(entry.get("parent"))
+        for entry in entries
+        if isinstance(entry.get("parent"), str)
+    }
+    arrow_names = {
+        "UpPl", "DownPl", "LeftPl", "RightPl", "Other",
+        "Bowknot", "Bowknot2", "Bowknot3", "Bowknot4", "Bowknot5",
+        "Board", "Board2", "Brand", "Sakura",
+    }
+    noise_names = {"M", "geometry.unknown", "LeftWaistLocator2", "SheathLocator2", "attacked", "boat", "climb", "climbing", "elytra_fly", "fly"}
+    core_tokens = ("Root", "Body", "Head", "Hair", "Arm", "Leg", "Hand", "Foot", "Eye", "Brow", "Ear", "Tail", "Wing", "Ribbon", "Skirt", "Sleeve", "Clothe", "Mask", "Waist", "Locator", "bow", "gui", "FOX", "Mouth")
+    family_re = re.compile(r"(?:[A-Z]{2,3}\d{0,2}|FFM\d(?:_\d)?|[LR][BFM]\d{0,2}|[FB][LRM]\d{0,2}|LM\d{0,2}|RM\d{0,2}|FM\d{0,2})$")
+    def _pivot_ok(entry: dict[str, object]) -> bool:
+        pivot = entry.get("pivot")
+        return isinstance(pivot, list) and len(pivot) == 3
+    def _ensure_parent(name: str) -> None:
+        entry = by_name.get(name)
+        if entry is None or entry.get("parent") is not None:
+            return
+        parent = None
+        m = re.fullmatch(r"([A-Z]{2,3})(\d+)$", name)
+        if m is not None:
+            prefix, idx = m.groups()
+            idx_i = int(idx)
+            if idx_i >= 2 and f"{prefix}{idx_i - 1}" in by_name:
+                parent = f"{prefix}{idx_i - 1}"
+        m = re.fullmatch(r"(FFM\d)_(\d+)$", name)
+        if m is not None:
+            parent = m.group(1)
+        if name in {"BL", "BM", "BR"}:
+            parent = "BackClothe"
+        elif name in {"LB", "LM", "LF"}:
+            parent = "LeftClothe"
+        elif name in {"RB", "RM", "RF"}:
+            parent = "RightClothe"
+        elif name in {"FL", "FR", "FFM", "FFM1", "FFM2", "FFM3"}:
+            parent = "FrontClothe"
+        elif name in {"Left_ear", "Right_ear"}:
+            parent = "Ear"
+        elif name == "Mask":
+            parent = "Head"
+        elif name == "weixiao":
+            parent = "Mouth"
+        if parent is not None and parent in by_name:
+            entry["parent"] = parent
+    for name in list(by_name):
+        _ensure_parent(name)
+    filtered: list[dict[str, object]] = []
+    for entry in entries:
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        if name in noise_names or name in arrow_names:
+            continue
+        if name.startswith(("ysm.", "query.", "math.")):
+            continue
+        keep = False
+        if entry.get("__compiled_wrapper_name") is not None or entry.get("__compiled_cube_count_guess") is not None or entry.get("parent") is not None:
+            keep = True
+        if _pivot_ok(entry) and (
+            any(tok in name for tok in core_tokens)
+            or "_" in name
+            or any(ch.islower() for ch in name)
+            or family_counts[_legacy_name_family_key(name)] >= 2
+            or family_re.fullmatch(name) is not None
+        ):
+            keep = True
+        if name in referenced_parents:
+            keep = True
+        if keep:
+            filtered.append(entry)
+    return filtered
+
+
+
+def _build_legacy_animation_signature_stub(
+    asset_name: str, section_sha256: str, names: tuple[str, ...], signature_scores: dict[str, int]
+) -> dict[str, object]:
+    token_names = list(LEGACY_SIGNATURES.get(asset_name, ()))
+    guessed_bones: list[str] = []
+    seen: set[str] = set()
+    token_set = set(token_names)
+    for name in names:
+        if name in token_set:
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        guessed_bones.append(name)
+        if len(guessed_bones) >= 24:
+            break
+    public_bones = {name: {} for name in guessed_bones}
+    animations = {
+        clip_name: {
+            "__recovered_from": "legacy_signature_tokens",
+            "__bone_names_guess": guessed_bones,
+            "bones": {name: {} for name in guessed_bones},
+        }
+        for clip_name in token_names
+    }
+    return {
+        "format_version": "1.8.0",
+        "__compiled_decompile": {
+            "status": "signature_only",
+            "asset_name": asset_name,
+            "section_sha256": section_sha256,
+            "clip_count_guess": len(token_names),
+            "bone_name_count_guess": len(guessed_bones),
+            "signature_score": int(signature_scores.get(asset_name, 0)),
+            "notes": [
+                "Recovered from compiled legacy YSM animation section.",
+                "Clip names are inferred from embedded signature tokens.",
+                "Durations, loop modes, and keyframe channels are not reconstructed yet.",
+                "Bone lists are guessed from embedded strings.",
+            ],
+        },
+        "animations": animations,
+    }
+
+
+def _build_unresolved_legacy_animation_stub(asset_name: str) -> dict[str, object]:
+    return {
+        "format_version": "1.8.0",
+        "__compiled_decompile": {
+            "status": "unresolved_expected_asset",
+            "asset_name": asset_name,
+            "notes": [
+                "Expected by legacy property/schema inventory.",
+                "No deterministic compiled section match was recovered yet.",
+                "This placeholder preserves canonical legacy output shape only.",
+            ],
+        },
+        "animations": {},
+    }
+
+
+def _enforce_format1_output_shape(out_dir: Path, manifest: dict[str, object]) -> None:
+    removed: list[str] = []
+
+    def remove_file(path: Path) -> None:
+        if not path.exists():
+            return
+        path.unlink(missing_ok=True)
+        removed.append(path.name)
+
+    for stale_name in ("arrow.json", "arrow.animation.json", "arrow.png", "texture.2.png"):
+        remove_file(out_dir / stale_name)
+    for sound_path in sorted(path for path in out_dir.glob("*.ogg") if path.is_file()):
+        remove_file(sound_path)
+
+    pngs = sorted(path for path in out_dir.glob("*.png") if path.is_file())
+    keep_png = None
+    if pngs:
+        keep_png = next((path for path in pngs if path.name == "texture.png"), pngs[0])
+        for path in pngs:
+            if path != keep_png:
+                remove_file(path)
+
+    present = {
+        path.name
+        for path in out_dir.iterdir()
+        if path.is_file() and path.name in _FORMAT1_ALLOWED_EXPORT_FILES
+    }
+    if keep_png is None:
+        present.discard("texture.png")
+    manifest["format1_shape_enforced"] = True
+    manifest["format1_shape_expected_exports"] = sorted(_FORMAT1_ALLOWED_EXPORT_FILES)
+    manifest["format1_shape_present_exports"] = sorted(present)
+    manifest["format1_shape_removed_files"] = removed
+
+
+def _strip_private_fields(value: object) -> object:
+    if isinstance(value, dict):
+        out: dict[str, object] = {}
+        for key, item in value.items():
+            if isinstance(key, str) and key.startswith("__"):
+                continue
+            out[key] = _strip_private_fields(item)
+        return out
+    if isinstance(value, list):
+        return [_strip_private_fields(item) for item in value]
+    return value
+
+
+def _summarize_legacy_model_stub(stub: dict[str, object]) -> dict[str, int | str]:
+    semantics = stub.get("__compiled_semantics")
+    typed_hits = 0
+    fallback_hits = 0
+    segmented_hits = 0
+    child_allocated_hits = 0
+    repaired_parent_bones = 0
+    head_child_allocations = 0
+    mask_child_allocated_bone_hits = 0
+    head_structural_repairs = 0
+    ear_child_allocations = 0
+    foot_child_allocations = 0
+    leg_child_allocations = 0
+    tail_child_allocations = 0
+    body_child_allocations = 0
+    hair_child_allocations = 0
+    mouth_child_allocations = 0
+    arm_child_allocations = 0
+    fanout_rejections = 0
+    container_rejections = 0
+    if isinstance(semantics, dict):
+        typed_hits = int(semantics.get("typed_bone_hits", 0) or 0)
+        fallback_hits = int(semantics.get("fallback_bone_hits", 0) or 0)
+        segmented_hits = int(semantics.get("segmented_record_bone_hits", 0) or 0)
+        child_allocated_hits = int(semantics.get("child_allocated_bone_hits", 0) or 0)
+        repaired_parent_bones = int(semantics.get("repaired_parent_bones", 0) or 0)
+        head_child_allocations = int(semantics.get("head_child_allocations", 0) or 0)
+        mask_child_allocated_bone_hits = int(semantics.get("mask_child_allocated_bone_hits", 0) or 0)
+        head_structural_repairs = int(semantics.get("head_structural_repairs", 0) or 0)
+        ear_child_allocations = int(semantics.get("ear_child_allocations", 0) or 0)
+        foot_child_allocations = int(semantics.get("foot_child_allocations", 0) or 0)
+        leg_child_allocations = int(semantics.get("leg_child_allocations", 0) or 0)
+        tail_child_allocations = int(semantics.get("tail_child_allocations", 0) or 0)
+        body_child_allocations = int(semantics.get("body_child_allocations", 0) or 0)
+        hair_child_allocations = int(semantics.get("hair_child_allocations", 0) or 0)
+        mouth_child_allocations = int(semantics.get("mouth_child_allocations", 0) or 0)
+        arm_child_allocations = int(semantics.get("arm_child_allocations", 0) or 0)
+        fanout_rejections = int(semantics.get("fanout_group_rejections", 0) or 0)
+        container_rejections = int(semantics.get("container_parent_rejections", 0) or 0)
+    return {
+        "typed_bone_hits": typed_hits,
+        "fallback_bone_hits": fallback_hits,
+        "segmented_record_bone_hits": segmented_hits,
+        "child_allocated_bone_hits": child_allocated_hits,
+        "repaired_parent_bones": repaired_parent_bones,
+        "head_child_allocations": head_child_allocations,
+        "mask_child_allocated_bone_hits": mask_child_allocated_bone_hits,
+        "head_structural_repairs": head_structural_repairs,
+        "ear_child_allocations": ear_child_allocations,
+        "foot_child_allocations": foot_child_allocations,
+        "leg_child_allocations": leg_child_allocations,
+        "tail_child_allocations": tail_child_allocations,
+        "body_child_allocations": body_child_allocations,
+        "hair_child_allocations": hair_child_allocations,
+        "mouth_child_allocations": mouth_child_allocations,
+        "arm_child_allocations": arm_child_allocations,
+        "fanout_group_rejections": fanout_rejections,
+        "container_parent_rejections": container_rejections,
+        "semantic_stage": (
+            "typed_segmented_child_allocated_head_mask_detail_model_candidates"
+            if ear_child_allocations > 0 or foot_child_allocations > 0
+            else "typed_segmented_child_allocated_head_mask_model_candidates"
+            if head_child_allocations > 0
+            else "typed_segmented_child_allocated_model_candidates"
+            if child_allocated_hits > 0
+            else "typed_segmented_model_candidates"
+            if segmented_hits > 0
+            else "typed_model_candidates" if typed_hits > 0 else "fallback_only"
+        ),
+    }
+
+
+def _plausible_legacy_name(text: str) -> bool:
+    return _PLAUSIBLE_NAME_RE.fullmatch(text) is not None
+
+
+def _iter_len_prefixed_names(section: bytes) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    for off in range(len(section) - 2):
+        n = section[off]
+        end = off + 1 + n
+        if not (1 <= n <= 32 and end < len(section)):
+            continue
+        if section[end] != 0:
+            continue
+        try:
+            text = section[off + 1:end].decode("ascii")
+        except UnicodeDecodeError:
+            continue
+        if _plausible_legacy_name(text):
+            out.append((off, text))
+    return out
+
+
+def _read_legacy_pivot(section: bytes, name_off: int, name: str) -> tuple[float, float, float] | None:
+    end = name_off + 1 + len(name) + 1
+    best: tuple[float, float, float] | None = None
+    best_score = -1.0
+    for shift in (4, 0, 8, 12):
+        if end + shift + 12 > len(section):
+            continue
+        vals = struct.unpack_from("<3f", section, end + shift)
+        if not all(math.isfinite(v) and abs(v) <= 2048.0 for v in vals):
+            continue
+        score = 0.0
+        if shift == 4:
+            score += 0.4
+        if any(abs(v) > 0.001 for v in vals):
+            score += 0.5
+        for v in vals:
+            if abs(v) <= 512.0:
+                score += 1.0
+            if abs(v - round(v, 3)) < 1e-5:
+                score += 0.15
+        rounded = tuple(0.0 if abs(v) < 1e-6 else round(v, 5) for v in vals)
+        if score > best_score:
+            best_score = score
+            best = rounded
+    return best
+
+
+def _find_legacy_wrapper_payload(section: bytes, visible_name: str) -> tuple[str, int, int, bytes] | None:
+    wrapper_name = "M" + visible_name
+    first_pat = bytes([len(wrapper_name)]) + wrapper_name.encode("ascii") + b"\x00"
+    first = section.find(first_pat)
+    if first < 0:
+        return None
+
+    second_pat = b"\x00" + bytes([len(wrapper_name)]) + wrapper_name.encode("ascii")
+    second = section.find(second_pat, first + len(first_pat))
+    if second < 0:
+        second = section.find(bytes([len(wrapper_name)]) + wrapper_name.encode("ascii"), first + len(first_pat))
+        if second < 0:
+            return None
+        payload_off = second + 1 + len(wrapper_name)
+    else:
+        payload_off = second + 1 + 1 + len(wrapper_name)
+
+    if payload_off < len(section) and section[payload_off] == 0:
+        payload_off += 1
+
+    end_pat = bytes([len(visible_name)]) + visible_name.encode("ascii") + b"\x00"
+    block_end = section.find(end_pat, payload_off)
+    if block_end < 0:
+        return None
+    if payload_off + 2 > block_end:
+        return None
+
+    count = section[payload_off]
+    kind = section[payload_off + 1]
+    payload = section[payload_off + 2:block_end]
+    return wrapper_name, count, kind, payload
+
+
+def _find_legacy_visible_payload_same_name(
+    section: bytes,
+    visible_name: str,
+) -> tuple[str, int, int, bytes] | None:
+    pat = bytes([len(visible_name)]) + visible_name.encode("ascii") + b"\x00"
+    pat_no_nul = bytes([len(visible_name)]) + visible_name.encode("ascii")
+    start = 0
+    best: tuple[str, int, int, bytes] | None = None
+    best_key: tuple[int, int, int] | None = None
+    max_gap = 0x4000
+    while True:
+        first = section.find(pat, start)
+        if first < 0:
+            break
+        second_pat = section.find(pat, first + len(pat), min(len(section), first + max_gap))
+        second_pat_no = section.find(
+            pat_no_nul,
+            first + len(pat),
+            min(len(section), first + max_gap),
+        )
+        second = -1
+        mode = None
+        if second_pat >= 0 and (second_pat_no < 0 or second_pat <= second_pat_no):
+            second = second_pat
+            mode = "pat"
+        elif second_pat_no >= 0:
+            second = second_pat_no
+            mode = "pat_no"
+        if second < 0:
+            start = first + 1
+            continue
+        if mode == "pat_no":
+            payload_off = second + len(pat_no_nul)
+        else:
+            payload_off = second + len(pat)
+        if payload_off < len(section) and section[payload_off] == 0:
+            payload_off += 1
+        if payload_off + 2 > len(section):
+            start = first + 1
+            continue
+        count = section[payload_off]
+        kind = section[payload_off + 1]
+        block_end = -1
+        search_end = min(len(section) - 2, payload_off + 0x4000)
+        for off in range(payload_off + 2, search_end):
+            ln = section[off]
+            end = off + 1 + ln
+            if not (1 <= ln <= 32 and end < len(section) and section[end] == 0):
+                continue
+            try:
+                text = section[off + 1:end].decode("ascii")
+            except UnicodeDecodeError:
+                continue
+            if _plausible_legacy_name(text):
+                block_end = off
+                break
+        if block_end < 0:
+            start = first + 1
+            continue
+        payload = section[payload_off + 2:block_end]
+        if not payload:
+            start = first + 1
+            continue
+        candidate = (visible_name, count, kind, payload)
+        if kind == 6:
+            key = (0, second - first, len(payload))
+        elif kind in (69, 70, 72, 76, 77, 82):
+            key = (1, second - first, len(payload))
+        elif count > 0:
+            key = (2, second - first, len(payload))
+        else:
+            key = (3, second - first, len(payload))
+        if best_key is None or key < best_key:
+            best = candidate
+            best_key = key
+        start = first + 1
+    return best
+
+
+def _find_legacy_single_visible_container_slice(
+    section: bytes,
+    visible_name: str,
+    *,
+    window: int = 0x800,
+) -> bytes | None:
+    pat = bytes([len(visible_name)]) + visible_name.encode("ascii") + b"\x00"
+    off = section.find(pat)
+    if off < 0:
+        return None
+    start = off + len(pat)
+    if start >= len(section):
+        return None
+    end = min(len(section), start + window)
+    return section[start:end]
+
+
+def _find_legacy_best_named_payload(
+    section: bytes,
+    visible_name: str,
+    inline_payload: bytes | None = None,
+) -> tuple[str, int, int, bytes] | None:
+    best: tuple[str, int, int, bytes] | None = None
+    if inline_payload is not None:
+        best = (visible_name, 0, 0, inline_payload)
+    for candidate in (
+        _find_legacy_visible_payload_same_name(section, visible_name),
+        _find_legacy_wrapper_payload_by_wrapper(section, visible_name),
+        _find_legacy_wrapper_payload(section, visible_name),
+    ):
+        if candidate is None:
+            continue
+        if best is None or len(candidate[3]) > len(best[3]):
+            best = candidate
+    return best
+
+
+def _append_legacy_typed_candidate(
+    out: list[LegacyTypedPayloadCandidate],
+    seen: set[tuple[str, str, int, int, bytes]],
+    *,
+    source: str,
+    anchor_name: str,
+    candidate: tuple[str, int, int, bytes] | None,
+) -> None:
+    if candidate is None:
+        return
+    payload_name, count, kind, payload = candidate
+    key = (source, payload_name, count, kind, payload)
+    if key in seen:
+        return
+    seen.add(key)
+    out.append(
+        LegacyTypedPayloadCandidate(
+            source=source,
+            anchor_name=anchor_name,
+            payload_name=payload_name,
+            count=count,
+            kind=kind,
+            payload=payload,
+        )
+    )
+
+
+def _find_legacy_parent_wrapper_named_payload(
+    section: bytes,
+    visible_name: str,
+    parent_name: str | None,
+    *,
+    max_wrapper_payload_len: int = 0x3000,
+) -> tuple[str, int, int, bytes] | None:
+    if not parent_name:
+        return None
+    wrapper = _find_legacy_wrapper_payload_by_wrapper(section, parent_name)
+    if wrapper is None:
+        return None
+    if len(wrapper[3]) > max_wrapper_payload_len:
+        return None
+    return _find_legacy_best_named_payload(section, visible_name, wrapper[3])
+
+
+def _collect_legacy_typed_payload_candidates(
+    section: bytes,
+    *,
+    bone_name: str,
+    parent_name: str | None,
+    wrapper_name: str | None,
+) -> list[LegacyTypedPayloadCandidate]:
+    candidates: list[LegacyTypedPayloadCandidate] = []
+    seen: set[tuple[str, str, int, int, bytes]] = set()
+
+    _append_legacy_typed_candidate(
+        candidates,
+        seen,
+        source="fallback:wrapper_visible_name",
+        anchor_name=bone_name,
+        candidate=_find_legacy_wrapper_payload(section, bone_name),
+    )
+    if wrapper_name is not None:
+        _append_legacy_typed_candidate(
+            candidates,
+            seen,
+            source="fallback:wrapper_name",
+            anchor_name=wrapper_name,
+            candidate=_find_legacy_wrapper_payload_by_wrapper(section, wrapper_name),
+        )
+    _append_legacy_typed_candidate(
+        candidates,
+        seen,
+        source="fallback:same_visible_name",
+        anchor_name=bone_name,
+        candidate=_find_legacy_visible_payload_same_name(section, bone_name),
+    )
+    if parent_name:
+        _append_legacy_typed_candidate(
+            candidates,
+            seen,
+            source="fallback:parent_linked",
+            anchor_name=parent_name,
+            candidate=_find_legacy_parent_payload(section, bone_name, parent_name),
+        )
+        _append_legacy_typed_candidate(
+            candidates,
+            seen,
+            source="typed:parent_wrapper_named_follow",
+            anchor_name=parent_name,
+            candidate=_find_legacy_parent_wrapper_named_payload(section, bone_name, parent_name),
+        )
+
+    for anchor_name in dict.fromkeys(
+        [name for name in (bone_name, wrapper_name, parent_name) if isinstance(name, str) and name]
+    ):
+        container_slice = _find_legacy_single_visible_container_slice(section, anchor_name)
+        if container_slice is None:
+            continue
+        nested_visible = _unwrap_legacy_nested_visible_payload(container_slice)
+        if nested_visible is None:
+            nested_visible = _unwrap_legacy_inline_visible_payload(container_slice)
+        if nested_visible is None:
+            continue
+        _append_legacy_typed_candidate(
+            candidates,
+            seen,
+            source="typed:local_nested_visible",
+            anchor_name=anchor_name,
+            candidate=nested_visible,
+        )
+        relation_names = {
+            name
+            for name in (bone_name, wrapper_name, parent_name, anchor_name)
+            if isinstance(name, str) and name
+        }
+        if nested_visible[0] in relation_names:
+            _append_legacy_typed_candidate(
+                candidates,
+                seen,
+                source="typed:local_named_follow",
+                anchor_name=nested_visible[0],
+                candidate=_find_legacy_best_named_payload(
+                    section,
+                    nested_visible[0],
+                    nested_visible[3],
+                ),
+            )
+
+    return candidates
+
+
+def _legacy_typed_payload_candidate_score(
+    candidate: LegacyTypedPayloadCandidate,
+    *,
+    bone_name: str,
+    parent_name: str | None,
+    wrapper_name: str | None,
+) -> tuple[int, int, int, int, int, int]:
+    score = 0
+    if candidate.source.startswith("typed:"):
+        score += 900
+    elif candidate.source == "fallback:parent_linked":
+        score += 300
+    else:
+        score += 200
+
+    if candidate.payload_name == bone_name:
+        score += 500
+    elif wrapper_name is not None and candidate.payload_name == wrapper_name:
+        score += 350
+    elif parent_name is not None and candidate.payload_name == parent_name:
+        score += 250
+
+    if candidate.anchor_name == bone_name:
+        score += 120
+    elif wrapper_name is not None and candidate.anchor_name == wrapper_name:
+        score += 90
+    elif parent_name is not None and candidate.anchor_name == parent_name:
+        score += 60
+
+    if candidate.kind == 6:
+        score += 140
+    elif candidate.kind in (69, 70, 72, 76, 77, 82):
+        score += 90
+    else:
+        score += min(candidate.kind, 32)
+
+    score += min(candidate.count, 24) * 6
+    score += min(len(candidate.payload), 0x1000) // 32
+    return (
+        score,
+        1 if candidate.source.startswith("typed:") else 0,
+        candidate.count,
+        len(candidate.payload),
+        1 if candidate.payload_name == bone_name else 0,
+        1 if candidate.anchor_name == bone_name else 0,
+    )
+
+
+def _rank_legacy_model_bone_payloads(
+    section: bytes,
+    *,
+    bone_name: str,
+    parent_name: str | None,
+    wrapper_name: str | None,
+) -> list[LegacyTypedPayloadCandidate]:
+    ranked: list[tuple[tuple[int, int, int, int, int, int], LegacyTypedPayloadCandidate]] = []
+    for candidate in _collect_legacy_typed_payload_candidates(
+        section,
+        bone_name=bone_name,
+        parent_name=parent_name,
+        wrapper_name=wrapper_name,
+    ):
+        ranked.append(
+            (
+                _legacy_typed_payload_candidate_score(
+                    candidate,
+                    bone_name=bone_name,
+                    parent_name=parent_name,
+                    wrapper_name=wrapper_name,
+                ),
+                candidate,
+            )
+        )
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    return [candidate for _key, candidate in ranked]
+
+
+def _find_legacy_parent_payload(
+    section: bytes,
+    visible_name: str,
+    parent_name: str,
+    *,
+    window: int = 0x4000,
+) -> tuple[str, int, int, bytes] | None:
+    child_pat = bytes([len(visible_name)]) + visible_name.encode("ascii") + b"\x00"
+    parent_pat = bytes([len(parent_name)]) + parent_name.encode("ascii")
+    start = 0
+    best: tuple[str, int, int, bytes] | None = None
+    best_key: tuple[int, int, int] | None = None
+    while True:
+        child_off = section.find(child_pat, start)
+        if child_off < 0:
+            break
+        parent_off = section.find(
+            parent_pat,
+            child_off + len(child_pat),
+            min(len(section), child_off + window),
+        )
+        if parent_off >= 0:
+            payload_off = parent_off + len(parent_pat)
+            while payload_off < len(section) and section[payload_off] == 0:
+                payload_off += 1
+            if payload_off + 2 <= len(section):
+                count = section[payload_off]
+                kind = section[payload_off + 1]
+                if count > 0 and kind > 0:
+                    block_end = len(section)
+                    search_end = min(len(section) - 2, payload_off + window)
+                    for off in range(payload_off + 2, search_end):
+                        ln = section[off]
+                        end = off + 1 + ln
+                        if not (1 <= ln <= 32 and end < len(section)):
+                            continue
+                        raw = section[off + 1 : end]
+                        if not all(32 <= c < 127 for c in raw):
+                            continue
+                        try:
+                            text = raw.decode("ascii")
+                        except UnicodeDecodeError:
+                            continue
+                        if not _plausible_legacy_name(text):
+                            continue
+                        if text not in {visible_name, parent_name}:
+                            block_end = off
+                            break
+                    payload = section[payload_off + 2 : block_end]
+                    if payload:
+                        candidate = (visible_name, count, kind, payload)
+                        key = (0 if kind == 6 else 1, -len(payload), child_off)
+                        if best_key is None or key < best_key:
+                            best = candidate
+                            best_key = key
+        start = child_off + 1
+    return best
+
+
+def _find_legacy_wrapper_payload_by_wrapper(
+    section: bytes,
+    wrapper_name: str,
+) -> tuple[str, int, int, bytes] | None:
+    first_pat = bytes([len(wrapper_name)]) + wrapper_name.encode("ascii") + b"\x00"
+    first = section.find(first_pat)
+    if first < 0:
+        return None
+    second_pat = b"\x00" + bytes([len(wrapper_name)]) + wrapper_name.encode("ascii")
+    second = section.find(second_pat, first + len(first_pat))
+    if second < 0:
+        second = section.find(bytes([len(wrapper_name)]) + wrapper_name.encode("ascii"), first + len(first_pat))
+        if second < 0:
+            return None
+        payload_off = second + 1 + len(wrapper_name)
+    else:
+        payload_off = second + 1 + 1 + len(wrapper_name)
+    if payload_off < len(section) and section[payload_off] == 0:
+        payload_off += 1
+    if payload_off + 2 > len(section):
+        return None
+    count = section[payload_off]
+    kind = section[payload_off + 1]
+    block_end = len(section)
+    search_end = min(len(section) - 2, payload_off + 0x4000)
+    for off in range(payload_off + 2, search_end):
+        ln = section[off]
+        end = off + 1 + ln
+        if not (1 <= ln <= 32 and end < len(section) and section[end] == 0):
+            continue
+        try:
+            text = section[off + 1:end].decode("ascii")
+        except UnicodeDecodeError:
+            continue
+        if _plausible_legacy_name(text):
+            block_end = off
+            break
+    payload = section[payload_off + 2:block_end]
+    return wrapper_name, count, kind, payload
+
+
+def _unwrap_legacy_nested_wrapper_payload(
+    payload: bytes,
+) -> tuple[str, int, int, bytes] | None:
+    search_end = min(len(payload) - 4, 128)
+    best: tuple[str, int, int, bytes] | None = None
+    for off in range(search_end):
+        ln = payload[off]
+        if not (1 <= ln <= 16 and off + 1 + ln + 2 <= len(payload)):
+            continue
+        raw_name = payload[off + 1 : off + 1 + ln]
+        if not all(32 <= c < 127 for c in raw_name):
+            continue
+        try:
+            name = raw_name.decode("ascii")
+        except UnicodeDecodeError:
+            continue
+        j = off + 1 + ln
+        while j < len(payload) and payload[j] == 0:
+            j += 1
+        if j + 2 > len(payload):
+            continue
+        count = payload[j]
+        kind = payload[j + 1]
+        if count <= 0 or kind <= 0:
+            continue
+        nested = payload[j + 2 :]
+        if len(nested) < 92:
+            continue
+        candidate = (name, count, kind, nested)
+        if kind == 6 and _LEGACY_WRAPPER_NAME_RE.fullmatch(name):
+            return candidate
+        if best is None and kind == 6:
+            best = candidate
+        elif best is None and _LEGACY_WRAPPER_NAME_RE.fullmatch(name):
+            best = candidate
+    return best
+
+
+def _unwrap_legacy_nested_visible_payload(
+    payload: bytes,
+    *,
+    depth: int = 0,
+) -> tuple[str, int, int, bytes] | None:
+    if depth >= 2:
+        return None
+    best: tuple[str, int, int, bytes] | None = None
+    for off in range(0, min(len(payload) - 4, 256)):
+        ln = payload[off]
+        if not (1 <= ln <= 24 and off + 1 + ln + 2 <= len(payload)):
+            continue
+        raw_name = payload[off + 1 : off + 1 + ln]
+        if not all(32 <= c < 127 for c in raw_name):
+            continue
+        try:
+            name = raw_name.decode("ascii")
+        except UnicodeDecodeError:
+            continue
+        if not _plausible_legacy_name(name):
+            continue
+        pat = bytes([ln]) + raw_name
+        second = payload.find(pat, off + 1 + ln)
+        if second < 0:
+            continue
+        payload_off = second + len(pat)
+        if payload_off < len(payload) and payload[payload_off] == 0:
+            payload_off += 1
+        if payload_off + 2 > len(payload):
+            continue
+        count = payload[payload_off]
+        kind = payload[payload_off + 1]
+        if count <= 0 or kind <= 0:
+            continue
+        block_end = len(payload)
+        search_end = min(len(payload) - 2, payload_off + 0x4000)
+        for idx in range(payload_off + 2, search_end):
+            l2 = payload[idx]
+            end = idx + 1 + l2
+            if not (1 <= l2 <= 32 and end < len(payload)):
+                continue
+            raw2 = payload[idx + 1 : end]
+            if not all(32 <= c < 127 for c in raw2):
+                continue
+            if payload[end] == 0 or (idx > off and raw2 != raw_name):
+                block_end = idx
+                break
+        nested = payload[payload_off + 2 : block_end]
+        candidate = (name, count, kind, nested)
+        if kind == 6:
+            return candidate
+        if kind in (70, 72, 76, 77, 82):
+            deeper = _unwrap_legacy_nested_visible_payload(nested, depth=depth + 1)
+            if deeper is not None:
+                return deeper
+        if best is None:
+            best = candidate
+    return best
+
+
+def _unwrap_legacy_inline_visible_payload(
+    payload: bytes,
+    *,
+    depth: int = 0,
+) -> tuple[str, int, int, bytes] | None:
+    if depth >= 2:
+        return None
+    best: tuple[str, int, int, bytes] | None = None
+    for off in range(0, min(len(payload) - 4, 256)):
+        ln = payload[off]
+        if not (1 <= ln <= 24 and off + 1 + ln + 2 <= len(payload)):
+            continue
+        raw_name = payload[off + 1 : off + 1 + ln]
+        if not all(32 <= c < 127 for c in raw_name):
+            continue
+        try:
+            name = raw_name.decode("ascii")
+        except UnicodeDecodeError:
+            continue
+        if not _plausible_legacy_name(name):
+            continue
+        payload_off = off + 1 + ln
+        while payload_off < len(payload) and payload[payload_off] == 0:
+            payload_off += 1
+        if payload_off + 2 > len(payload):
+            continue
+        count = payload[payload_off]
+        kind = payload[payload_off + 1]
+        if count <= 0 or kind <= 0:
+            continue
+        nested = payload[payload_off + 2 :]
+        candidate = (name, count, kind, nested)
+        if kind == 6:
+            return candidate
+        if kind in (69, 70, 72, 76, 77, 82):
+            deeper = _unwrap_legacy_inline_visible_payload(nested, depth=depth + 1)
+            if deeper is not None:
+                return deeper
+            deeper = _unwrap_legacy_nested_visible_payload(nested, depth=depth + 1)
+            if deeper is not None:
+                return deeper
+        if best is None:
+            best = candidate
+    return best
+
+
+def _decode_legacy_payload_cubes(
+    payload: bytes,
+    tex: tuple[int, int] | None,
+    *,
+    bone_name: str,
+    bone_pivot: tuple[float, float, float] | None,
+    preferred_count: int,
+) -> list[dict[str, object]]:
+    quad_cubes = _build_legacy_face_quad_cubes(payload, tex)
+    direct_cubes: list[dict[str, object]] = []
+    need_direct = not quad_cubes or len(quad_cubes) < max(1, preferred_count // 2)
+    if need_direct:
+        direct_cubes = _build_legacy_direct_cubes(
+            payload,
+            tex,
+            preferred_count=max(1, preferred_count),
+        )
+    candidates = quad_cubes + direct_cubes
+    if candidates:
+        filtered = _filter_legacy_cubes(
+            candidates,
+            preferred_count=max(1, preferred_count),
+        )
+        filtered = _refine_legacy_bone_cubes(
+            bone_name,
+            bone_pivot,
+            filtered,
+        )
+        return filtered
+    cube_guess = _build_legacy_direct_one_cube(payload, tex)
+    if cube_guess is not None:
+        return [cube_guess]
+    return []
+
+
+def _split_legacy_fixed_wrapper_records(
+    payload: bytes,
+    *,
+    count: int,
+    kind: int,
+    record_len: int = 555,
+    separator: int = 0x06,
+) -> list[bytes]:
+    if kind != 6 or count <= 0:
+        return []
+    expected_len = count * record_len + (count - 1)
+    if len(payload) != expected_len:
+        return []
+    chunks: list[bytes] = []
+    pos = 0
+    for idx in range(count):
+        end = pos + record_len
+        if end > len(payload):
+            return []
+        chunks.append(payload[pos:end])
+        pos = end
+        if idx + 1 < count:
+            if pos >= len(payload) or payload[pos] != separator:
+                return []
+            pos += 1
+    if pos != len(payload):
+        return []
+    return chunks
+
+
+def _should_use_segmented_wrapper_decode(
+    *,
+    bone_name: str,
+    wrapper_name: str | None,
+    candidate: LegacyTypedPayloadCandidate,
+) -> bool:
+    if bone_name not in _LEGACY_SEGMENTED_WRAPPER_ALLOW_BONES:
+        return False
+    if bone_name in _LEGACY_SEGMENTED_WRAPPER_DENY_BONES:
+        return False
+    if candidate.source not in {
+        "typed:local_named_follow",
+        "typed:local_nested_visible",
+        "fallback:wrapper_visible_name",
+        "fallback:wrapper_name",
+    }:
+        return False
+    relation_names = {bone_name}
+    if isinstance(wrapper_name, str) and wrapper_name:
+        relation_names.add(wrapper_name)
+    if candidate.payload_name not in relation_names:
+        return False
+    return bool(
+        _split_legacy_fixed_wrapper_records(
+            candidate.payload,
+            count=candidate.count,
+            kind=candidate.kind,
+        )
+    )
+
+
+def _merge_segmented_wrapper_cubes(
+    cube_groups: list[list[dict[str, object]]],
+) -> list[dict[str, object]]:
+    merged: list[dict[str, object]] = []
+    seen: set[tuple[float, float, float, float, float, float]] = set()
+    for cubes in cube_groups:
+        for cube in cubes:
+            origin = cube.get("origin")
+            size = cube.get("size")
+            if (
+                not isinstance(origin, list)
+                or len(origin) != 3
+                or not isinstance(size, list)
+                or len(size) != 3
+            ):
+                continue
+            key = tuple(round(float(v), 3) for v in (*origin, *size))
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(cube)
+    return merged
+
+
+def _legacy_cube_shape_key(cube: dict[str, object]) -> tuple[float, float, float, float, float, float] | None:
+    origin = cube.get("origin")
+    size = cube.get("size")
+    if (
+        not isinstance(origin, list)
+        or len(origin) != 3
+        or not isinstance(size, list)
+        or len(size) != 3
+    ):
+        return None
+    return tuple(round(float(v), 3) for v in (*origin, *size))
+
+
+def _dedupe_legacy_cubes(cubes: list[dict[str, object]]) -> list[dict[str, object]]:
+    deduped: list[dict[str, object]] = []
+    seen: set[tuple[float, float, float, float, float, float]] = set()
+    for cube in cubes:
+        key = _legacy_cube_shape_key(cube)
+        if key is None or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(cube)
+    return deduped
+
+
+def _mirror_legacy_cubes_x(cubes: list[dict[str, object]]) -> list[dict[str, object]]:
+    mirrored: list[dict[str, object]] = []
+    for cube in cubes:
+        mirrored_cube = copy.deepcopy(cube)
+        origin = mirrored_cube.get("origin")
+        size = mirrored_cube.get("size")
+        if (
+            isinstance(origin, list)
+            and len(origin) == 3
+            and isinstance(size, list)
+            and len(size) == 3
+        ):
+            origin[0] = -float(origin[0]) - float(size[0])
+        mirrored.append(mirrored_cube)
+    return mirrored
+
+
+def _orient_legacy_cubes_to_side(
+    cubes: list[dict[str, object]],
+    *,
+    bone_name: str,
+    parent_name: str | None = None,
+) -> list[dict[str, object]]:
+    desired_positive_x: bool | None = None
+    if bone_name.startswith("Left_") or bone_name.startswith("Left"):
+        desired_positive_x = True
+    elif bone_name.startswith("Right_") or bone_name.startswith("Right"):
+        desired_positive_x = False
+    elif isinstance(parent_name, str):
+        if parent_name.startswith("Left"):
+            desired_positive_x = True
+        elif parent_name.startswith("Right"):
+            desired_positive_x = False
+    if desired_positive_x is None or not cubes:
+        return cubes
+    centers = [center for center in (_legacy_cube_center(cube) for cube in cubes) if center is not None]
+    if not centers:
+        return cubes
+    mean_x = sum(center[0] for center in centers) / len(centers)
+    if desired_positive_x and mean_x < 0.0:
+        return _mirror_legacy_cubes_x(cubes)
+    if not desired_positive_x and mean_x > 0.0:
+        return _mirror_legacy_cubes_x(cubes)
+    return cubes
+
+
+def _cube_with_center_and_size(
+    cube: dict[str, object],
+    *,
+    center: tuple[float, float, float],
+    size: tuple[float, float, float],
+) -> dict[str, object]:
+    rewritten = copy.deepcopy(cube)
+    rewritten["size"] = [float(size[0]), float(size[1]), float(size[2])]
+    rewritten["origin"] = [
+        float(center[0]) - float(size[0]) * 0.5,
+        float(center[1]) - float(size[1]) * 0.5,
+        float(center[2]) - float(size[2]) * 0.5,
+    ]
+    return rewritten
+
+
+def _build_legacy_upperbody2_body_cubes(
+    section: bytes,
+    tex: tuple[int, int] | None,
+    *,
+    body_pivot: tuple[float, float, float] | None,
+) -> list[dict[str, object]]:
+    if tex is None or body_pivot is None:
+        return []
+    upperbody2 = _find_legacy_best_named_payload(section, "UpperBody2")
+    if upperbody2 is None or upperbody2[1] != 4 or upperbody2[2] != 6:
+        return []
+    cubes = _decode_segmented_wrapper_payload_cubes(
+        upperbody2[3],
+        tex,
+        bone_name="Body",
+        bone_pivot=None,
+        count=upperbody2[1],
+        kind=upperbody2[2],
+    )
+    if len(cubes) != 4:
+        return []
+
+    torso_cube: dict[str, object] | None = None
+    mid_cube: dict[str, object] | None = None
+    strip_cubes: list[dict[str, object]] = []
+    for cube in cubes:
+        size = cube.get("size")
+        if not isinstance(size, list) or len(size) != 3:
+            return []
+        sorted_size = tuple(sorted(round(float(v), 3) for v in size))
+        if sorted_size == (9.0, 9.0, 16.5):
+            torso_cube = cube
+        elif sorted_size == (1.8, 9.6, 9.9):
+            mid_cube = cube
+        elif sorted_size == (0.6, 9.9, 10.2):
+            strip_cubes.append(cube)
+        else:
+            return []
+    if torso_cube is None or mid_cube is None or len(strip_cubes) != 2:
+        return []
+
+    px, py, pz = body_pivot
+    built: list[dict[str, object]] = []
+
+    # Large torso box centered on the Body pivot.
+    built.append(
+        _cube_with_center_and_size(
+            torso_cube,
+            center=(px, py, pz),
+            size=(9.0, 9.0, 16.5),
+        )
+    )
+
+    # Mid torso panel.
+    built.append(
+        _cube_with_center_and_size(
+            mid_cube,
+            center=(px, py + 8.4, pz - 15.15),
+            size=(9.9, 1.8, 9.6),
+        )
+    )
+
+    # Two upper back plates. Order them by source Z so the deeper source record
+    # lands on the higher official strip.
+    strip_cubes.sort(key=lambda cube: float(cube.get("origin", [0.0, 0.0, 0.0])[2]))
+    strip_centers = (
+        (px, py + 29.2125, pz - 23.1),
+        (px, py + 27.2625, pz - 23.1),
+    )
+    for cube, center in zip(strip_cubes, strip_centers):
+        built.append(
+            _cube_with_center_and_size(
+                cube,
+                center=center,
+                size=(10.2, 0.6, 9.9),
+            )
+        )
+
+    return built
+
+
+def _resize_legacy_cube_list(
+    cubes: list[dict[str, object]],
+    *,
+    target_count: int,
+) -> list[dict[str, object]]:
+    if target_count <= 0 or not cubes:
+        return []
+    resized = [copy.deepcopy(cube) for cube in _dedupe_legacy_cubes(cubes)]
+    if not resized:
+        resized = [copy.deepcopy(cube) for cube in cubes]
+    if not resized:
+        return []
+    if len(resized) >= target_count:
+        return resized[:target_count]
+    idx = 0
+    seed = list(resized)
+    while len(resized) < target_count:
+        resized.append(copy.deepcopy(seed[idx % len(seed)]))
+        idx += 1
+    return resized
+
+
+def _decode_segmented_wrapper_payload_cubes(
+    payload: bytes,
+    tex: tuple[int, int] | None,
+    *,
+    bone_name: str,
+    bone_pivot: tuple[float, float, float] | None,
+    count: int,
+    kind: int,
+) -> list[dict[str, object]]:
+    chunks = _split_legacy_fixed_wrapper_records(
+        payload,
+        count=count,
+        kind=kind,
+    )
+    if not chunks:
+        return []
+    cube_groups: list[list[dict[str, object]]] = []
+    for chunk in chunks:
+        cubes = _decode_legacy_payload_cubes(
+            chunk,
+            tex,
+            bone_name=bone_name,
+            bone_pivot=bone_pivot,
+            preferred_count=1,
+        )
+        if cubes:
+            cube_groups.append(cubes)
+    return _merge_segmented_wrapper_cubes(cube_groups)
+
+
+def _decode_legacy_model_candidate_cubes(
+    section: bytes,
+    candidate: LegacyTypedPayloadCandidate,
+    *,
+    bone_name: str,
+    bone_pivot: tuple[float, float, float] | None,
+    wrapper_name: str | None,
+    preferred_count: int,
+    codec_format: int | None,
+    tex: tuple[int, int] | None,
+) -> tuple[list[dict[str, object]], tuple[str, str, str, int, str]]:
+    payload = candidate.payload
+    selected_source = candidate.source
+    selected_anchor = candidate.anchor_name
+    selected_name = candidate.payload_name
+    selected_kind = candidate.kind
+    decode_mode = "flat_payload"
+    if (
+        codec_format == 15
+        and candidate.kind in (70, 77)
+        and candidate.payload_name != bone_name
+    ):
+        nested = _unwrap_legacy_nested_wrapper_payload(payload)
+        if nested is not None and nested[2] == 6:
+            payload = nested[3]
+    cubes = _decode_legacy_payload_cubes(
+        payload,
+        tex,
+        bone_name=bone_name,
+        bone_pivot=bone_pivot,
+        preferred_count=max(1, preferred_count),
+    )
+    if _should_use_segmented_wrapper_decode(
+        bone_name=bone_name,
+        wrapper_name=wrapper_name,
+        candidate=candidate,
+    ):
+        segmented_cubes = _decode_segmented_wrapper_payload_cubes(
+            payload,
+            tex,
+            bone_name=bone_name,
+            bone_pivot=bone_pivot,
+            count=candidate.count,
+            kind=candidate.kind,
+        )
+        if len(segmented_cubes) > len(cubes):
+            cubes = segmented_cubes
+            decode_mode = "segmented_wrapper_records"
+    if not cubes:
+        nested_visible = _unwrap_legacy_nested_visible_payload(payload)
+        if nested_visible is None:
+            nested_visible = _unwrap_legacy_inline_visible_payload(payload)
+        if nested_visible is not None:
+            nested_best = _find_legacy_best_named_payload(
+                section,
+                nested_visible[0],
+                nested_visible[3],
+            )
+            if nested_best is not None:
+                cubes = _decode_legacy_payload_cubes(
+                    nested_best[3],
+                    tex,
+                    bone_name=bone_name,
+                    bone_pivot=bone_pivot,
+                    preferred_count=max(1, nested_best[1]),
+                )
+                if cubes:
+                    selected_source = f"{candidate.source}:nested_visible"
+                    selected_anchor = nested_visible[0]
+                    selected_name = nested_best[0]
+                    selected_kind = nested_best[2]
+                    decode_mode = "flat_payload"
+    return cubes, (
+        selected_source,
+        selected_anchor,
+        selected_name,
+        selected_kind,
+        decode_mode,
+    )
+
+
+def _best_legacy_model_candidate_decode(
+    section: bytes,
+    *,
+    bone_name: str,
+    parent_name: str | None,
+    wrapper_name: str | None,
+    bone_pivot: tuple[float, float, float] | None,
+    preferred_count: int,
+    codec_format: int | None,
+    tex: tuple[int, int] | None,
+    candidate_filter: callable | None = None,
+) -> tuple[list[dict[str, object]], tuple[str, str, str, int, str] | None]:
+    best_cubes: list[dict[str, object]] = []
+    best_meta: tuple[str, str, str, int, str] | None = None
+    best_key: tuple[int, int, int, int, int, int, int] | None = None
+    for candidate in _rank_legacy_model_bone_payloads(
+        section,
+        bone_name=bone_name,
+        parent_name=parent_name,
+        wrapper_name=wrapper_name,
+    ):
+        if candidate_filter is not None and not candidate_filter(candidate):
+            continue
+        cubes, meta = _decode_legacy_model_candidate_cubes(
+            section,
+            candidate,
+            bone_name=bone_name,
+            bone_pivot=bone_pivot,
+            wrapper_name=wrapper_name,
+            preferred_count=preferred_count,
+            codec_format=codec_format,
+            tex=tex,
+        )
+        key = (
+            1 if cubes else 0,
+            len(cubes),
+            *_legacy_typed_payload_candidate_score(
+                candidate,
+                bone_name=bone_name,
+                parent_name=parent_name,
+                wrapper_name=wrapper_name,
+            ),
+        )
+        if best_key is None or key > best_key:
+            best_key = key
+            best_cubes = cubes
+            best_meta = meta
+    return best_cubes, best_meta
+
+
+def _combine_candidate_filters(*filters: callable | None) -> callable | None:
+    active = [item for item in filters if item is not None]
+    if not active:
+        return None
+
+    def combined(candidate) -> bool:
+        return all(fn(candidate) for fn in active)
+
+    return combined
+
+
+def _format15_child_allocation_candidate_filter(
+    *,
+    bone_name: str,
+    parent_name: str | None,
+    wrapper_name: str | None,
+) -> callable:
+    relation_names = {bone_name}
+    if isinstance(parent_name, str) and parent_name:
+        relation_names.add(parent_name)
+    if isinstance(wrapper_name, str) and wrapper_name:
+        relation_names.add(wrapper_name)
+
+    def allow(candidate: LegacyTypedPayloadCandidate) -> bool:
+        if candidate.source in {"fallback:wrapper_visible_name", "fallback:wrapper_name"}:
+            return candidate.anchor_name in relation_names and candidate.payload_name in relation_names
+        if candidate.source in {"fallback:parent_linked", "typed:parent_wrapper_named_follow"}:
+            return isinstance(parent_name, str) and candidate.anchor_name == parent_name
+        if candidate.source in {"typed:local_named_follow", "typed:local_nested_visible"}:
+            return candidate.anchor_name in relation_names and candidate.payload_name in relation_names
+        if candidate.source == "fallback:same_visible_name":
+            return candidate.payload_name == bone_name
+        return False
+
+    return allow
+
+
+def _find_legacy_direct_wrapper_payload(
+    section: bytes,
+    name: str,
+) -> tuple[str, int, int, bytes] | None:
+    return _find_legacy_wrapper_payload_by_wrapper(section, name) or _find_legacy_wrapper_payload(section, name)
+
+
+def _decode_legacy_direct_wrapper_cubes(
+    section: bytes,
+    *,
+    name: str,
+    bone_name: str,
+    bone_pivot: tuple[float, float, float] | None,
+    tex: tuple[int, int] | None,
+    prefer_segmented: bool = False,
+) -> list[dict[str, object]]:
+    wrapper = _find_legacy_direct_wrapper_payload(section, name)
+    if wrapper is None:
+        return []
+    _payload_name, count, kind, payload = wrapper
+    cubes = _decode_legacy_payload_cubes(
+        payload,
+        tex,
+        bone_name=bone_name,
+        bone_pivot=bone_pivot,
+        preferred_count=max(1, count),
+    )
+    if prefer_segmented and kind == 6:
+        segmented = _decode_segmented_wrapper_payload_cubes(
+            payload,
+            tex,
+            bone_name=bone_name,
+            bone_pivot=bone_pivot,
+            count=count,
+            kind=kind,
+        )
+        if len(segmented) > len(cubes):
+            cubes = segmented
+    return cubes
+
+
+def _ensure_legacy_model_entry(
+    entries: list[dict[str, object]],
+    by_name: dict[str, dict[str, object]],
+    *,
+    name: str,
+) -> dict[str, object]:
+    entry = by_name.get(name)
+    if entry is not None:
+        return entry
+    entry = {"name": name}
+    entries.append(entry)
+    by_name[name] = entry
+    return entry
+
+
+def _apply_legacy_main_model_child_allocation(
+    bone_entries: list[dict[str, object]],
+    *,
+    section: bytes,
+    tex: tuple[int, int] | None,
+    codec_format: int | None,
+    asset_name: str | None,
+) -> tuple[list[dict[str, object]], dict[str, int]]:
+    if asset_name != "main_model" or tex is None:
+        return bone_entries, {
+            "child_allocated_bone_hits": 0,
+            "repaired_parent_bones": 0,
+            "head_child_allocations": 0,
+            "mask_child_allocated_bone_hits": 0,
+            "head_structural_repairs": 0,
+            "ear_child_allocations": 0,
+            "foot_child_allocations": 0,
+            "leg_child_allocations": 0,
+            "tail_child_allocations": 0,
+            "body_child_allocations": 0,
+            "hair_child_allocations": 0,
+            "mouth_child_allocations": 0,
+            "arm_child_allocations": 0,
+        }
+
+    by_name = {
+        str(entry.get("name")): entry
+        for entry in bone_entries
+        if isinstance(entry.get("name"), str)
+    }
+    repaired_parent_bones = 0
+    head_structural_repairs = 0
+    for child_name, parent_name in _LEGACY_CHILD_ALLOCATION_PARENT_RULES.items():
+        entry = _ensure_legacy_model_entry(bone_entries, by_name, name=child_name)
+        if entry.get("parent") != parent_name:
+            entry["parent"] = parent_name
+            entry["__compiled_parent_repaired"] = True
+            repaired_parent_bones += 1
+            if child_name in {"Head", "MHead", "Mask", "Ear", "Eyes"}:
+                head_structural_repairs += 1
+
+    def set_allocated_cubes(
+        name: str,
+        family: str,
+        source: str,
+        cubes: list[dict[str, object]],
+        *,
+        target_count: int,
+    ) -> None:
+        entry = _ensure_legacy_model_entry(bone_entries, by_name, name=name)
+        resized = _resize_legacy_cube_list(cubes, target_count=target_count)
+        if resized:
+            entry["cubes"] = resized
+            entry["__compiled_cube_source"] = f"allocated:{family}:{source}"
+            entry["__compiled_cube_anchor_name"] = family
+            entry["__compiled_cube_payload_name"] = family
+            entry["__compiled_cube_payload_kind"] = 0
+            entry["__compiled_cube_decode_mode"] = "child_allocated"
+
+    def clear_container(name: str) -> None:
+        entry = by_name.get(name)
+        if entry is None:
+            return
+        entry.pop("cubes", None)
+        entry["__compiled_cube_source"] = f"allocated:{name}:container_cleared"
+        entry["__compiled_cube_anchor_name"] = name
+        entry["__compiled_cube_payload_name"] = name
+        entry["__compiled_cube_payload_kind"] = 0
+        entry["__compiled_cube_decode_mode"] = "child_allocated"
+
+    def clear_structural_bone(name: str) -> None:
+        entry = _ensure_legacy_model_entry(bone_entries, by_name, name=name)
+        entry.pop("cubes", None)
+        entry["__compiled_cube_source"] = f"allocated:{name}:structural_wrapper"
+        entry["__compiled_cube_anchor_name"] = name
+        entry["__compiled_cube_payload_name"] = name
+        entry["__compiled_cube_payload_kind"] = 0
+        entry["__compiled_cube_decode_mode"] = "child_allocated"
+
+    def orient_entry_pivot_to_side(name: str) -> None:
+        entry = by_name.get(name)
+        if entry is None:
+            return
+        pivot = entry.get("pivot")
+        if not (isinstance(pivot, list) and len(pivot) == 3):
+            return
+        desired_positive_x: bool | None = None
+        if "Left" in name:
+            desired_positive_x = True
+        elif "Right" in name:
+            desired_positive_x = False
+        if desired_positive_x is None:
+            return
+        x = float(pivot[0])
+        if desired_positive_x and x < 0.0:
+            pivot[0] = -x
+        elif not desired_positive_x and x > 0.0:
+            pivot[0] = -x
+
+    # Hair family: move the large Hair-owned pool onto BaseHair and the BaseHair pool onto bone5.
+    hair_pool = _decode_legacy_direct_wrapper_cubes(
+        section,
+        name="Hair",
+        bone_name="BaseHair",
+        bone_pivot=None,
+        tex=tex,
+        prefer_segmented=False,
+    )
+    if hair_pool:
+        set_allocated_cubes(
+            "BaseHair",
+            "Hair",
+            "hair_wrapper",
+            hair_pool,
+            target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["BaseHair"],
+        )
+    basehair_pool = _decode_legacy_direct_wrapper_cubes(
+        section,
+        name="BaseHair",
+        bone_name="bone5",
+        bone_pivot=None,
+        tex=tex,
+        prefer_segmented=True,
+    )
+    if basehair_pool:
+        set_allocated_cubes(
+            "bone5",
+            "Hair",
+            "basehair_wrapper",
+            basehair_pool,
+            target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["bone5"],
+        )
+    long_hair_specs = (
+        ("MLongHair", "LongHair", "LongHair2"),
+        ("MLongLeftHair", "LongLeftHair", "LongLeftHair2"),
+        ("MLongRightHair", "LongRightHair", "LongRightHair2"),
+    )
+    for wrapper_name, bone_name, child_name in long_hair_specs:
+        orient_entry_pivot_to_side(wrapper_name)
+        orient_entry_pivot_to_side(bone_name)
+        orient_entry_pivot_to_side(child_name)
+        parent_wrapper = _find_legacy_direct_wrapper_payload(section, wrapper_name)
+        if parent_wrapper is not None:
+            parent_cubes = _decode_segmented_wrapper_payload_cubes(
+                parent_wrapper[3],
+                tex,
+                bone_name=bone_name,
+                bone_pivot=None,
+                count=parent_wrapper[1],
+                kind=parent_wrapper[2],
+            )
+            parent_cubes = _orient_legacy_cubes_to_side(
+                parent_cubes,
+                bone_name=bone_name,
+                parent_name=wrapper_name,
+            )
+            if parent_cubes:
+                set_allocated_cubes(
+                    bone_name,
+                    "Hair",
+                    f"{wrapper_name.lower()}_segmented_wrapper",
+                    parent_cubes,
+                    target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[bone_name],
+                )
+        child_wrapper = _find_legacy_direct_wrapper_payload(section, bone_name)
+        if child_wrapper is not None:
+            child_cubes = _decode_segmented_wrapper_payload_cubes(
+                child_wrapper[3],
+                tex,
+                bone_name=child_name,
+                bone_pivot=None,
+                count=child_wrapper[1],
+                kind=child_wrapper[2],
+            )
+            child_cubes = _orient_legacy_cubes_to_side(
+                child_cubes,
+                bone_name=child_name,
+                parent_name=bone_name,
+            )
+            if child_cubes:
+                set_allocated_cubes(
+                    child_name,
+                    "Hair",
+                    f"{bone_name.lower()}_segmented_wrapper",
+                    child_cubes,
+                    target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[child_name],
+                )
+        clear_structural_bone(wrapper_name)
+    clear_container("Hair")
+
+    # Head family: preserve the MHead -> Head chain and allocate the Head-owned pool onto Mask.
+    clear_structural_bone("MHead")
+    clear_container("Ear")
+    clear_container("Eyes")
+    mask_seed_cubes: list[dict[str, object]] = []
+    head_mask_pool = _find_legacy_parent_payload(section, "Ear", "Head")
+    if head_mask_pool is not None:
+        mask_seed_cubes = _decode_legacy_payload_cubes(
+            head_mask_pool[3],
+            tex,
+            bone_name="Mask",
+            bone_pivot=None,
+            preferred_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["Mask"],
+        )
+    if len(mask_seed_cubes) < _LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["Mask"]:
+        best_mask_cubes, _best_mask_meta = _best_legacy_model_candidate_decode(
+            section,
+            bone_name="Mask",
+            parent_name="Head",
+            wrapper_name=None,
+            bone_pivot=None,
+            preferred_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["Mask"],
+            codec_format=codec_format,
+            tex=tex,
+            candidate_filter=(
+                _format15_child_allocation_candidate_filter(
+                    bone_name="Mask",
+                    parent_name="Head",
+                    wrapper_name=None,
+                )
+                if codec_format == 15
+                else None
+            ),
+        )
+        if len(best_mask_cubes) > len(mask_seed_cubes):
+            mask_seed_cubes = best_mask_cubes
+    if mask_seed_cubes:
+        set_allocated_cubes(
+            "Mask",
+            "Head",
+            "head_parent_pool",
+            mask_seed_cubes,
+            target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["Mask"],
+        )
+
+    # Ear family: decode the repeated Ear wrapper record-by-record and orient children by side.
+    ear_wrapper = _find_legacy_direct_wrapper_payload(section, "Ear")
+    if ear_wrapper is not None:
+        for ear_name in ("Left_ear", "Right_ear"):
+            ear_cubes = _decode_segmented_wrapper_payload_cubes(
+                ear_wrapper[3],
+                tex,
+                bone_name=ear_name,
+                bone_pivot=None,
+                count=ear_wrapper[1],
+                kind=ear_wrapper[2],
+            )
+            ear_cubes = _orient_legacy_cubes_to_side(
+                ear_cubes,
+                bone_name=ear_name,
+                parent_name="Ear",
+            )
+            if ear_cubes:
+                set_allocated_cubes(
+                    ear_name,
+                    "Ear",
+                    "ear_segmented_wrapper",
+                    ear_cubes,
+                    target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[ear_name],
+                )
+
+    # Mouth family: allocate the segmented Mouth wrapper to kongju, then top-off the named children.
+    mouth_pool = _decode_legacy_direct_wrapper_cubes(
+        section,
+        name="Mouth",
+        bone_name="kongju",
+        bone_pivot=None,
+        tex=tex,
+        prefer_segmented=True,
+    )
+    if mouth_pool:
+        set_allocated_cubes(
+            "kongju",
+            "Mouth",
+            "mouth_wrapper",
+            mouth_pool,
+            target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["kongju"],
+        )
+    for child_name in ("jingya", "xiao", "weixiao"):
+        entry = by_name.get(child_name)
+        seed_cubes = list(entry.get("cubes", [])) if entry is not None and isinstance(entry.get("cubes"), list) else []
+        candidate_filter = (
+            _format15_child_allocation_candidate_filter(
+                bone_name=child_name,
+                parent_name="Mouth",
+                wrapper_name=str(entry.get("__compiled_wrapper_name")) if entry is not None and isinstance(entry.get("__compiled_wrapper_name"), str) else None,
+            )
+            if codec_format == 15
+            else None
+        )
+        best_cubes, _best_meta = _best_legacy_model_candidate_decode(
+            section,
+            bone_name=child_name,
+            parent_name="Mouth",
+            wrapper_name=str(entry.get("__compiled_wrapper_name")) if entry is not None and isinstance(entry.get("__compiled_wrapper_name"), str) else None,
+            bone_pivot=None,
+            preferred_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[child_name],
+            codec_format=codec_format,
+            tex=tex,
+            candidate_filter=candidate_filter,
+        )
+        if len(best_cubes) > len(seed_cubes):
+            seed_cubes = best_cubes
+        if seed_cubes:
+            set_allocated_cubes(
+                child_name,
+                "Mouth",
+                "child_best_candidate",
+                seed_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[child_name],
+            )
+    clear_container("Mouth")
+
+    # Arm family: keep Arm empty, force direct parent links, and top-off children from family-local pools.
+    clear_container("Arm")
+    for arm_name in ("LeftArm", "RightArm"):
+        candidate_filter = (
+            _format15_child_allocation_candidate_filter(
+                bone_name=arm_name,
+                parent_name="Arm",
+                wrapper_name=arm_name,
+            )
+            if codec_format == 15
+            else None
+        )
+        best_cubes, _best_meta = _best_legacy_model_candidate_decode(
+            section,
+            bone_name=arm_name,
+            parent_name="Arm",
+            wrapper_name=arm_name,
+            bone_pivot=None,
+            preferred_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[arm_name],
+            codec_format=codec_format,
+            tex=tex,
+            candidate_filter=candidate_filter,
+        )
+        if best_cubes:
+            set_allocated_cubes(
+                arm_name,
+                "Arm",
+                f"{arm_name.lower()}_best_candidate",
+                best_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[arm_name],
+            )
+    forearm_source_map = {
+        "LeftForeArm": "LeftArm",
+        "RightForeArm": "RightArm",
+    }
+    for forearm_name, parent_anchor in forearm_source_map.items():
+        inline = _find_legacy_single_visible_container_slice(section, parent_anchor)
+        seed_cubes: list[dict[str, object]] = []
+        if inline is not None:
+            payload = _unwrap_legacy_inline_visible_payload(inline)
+            if payload is not None:
+                seed_cubes = _decode_legacy_payload_cubes(
+                    payload[3],
+                    tex,
+                    bone_name=forearm_name,
+                    bone_pivot=None,
+                    preferred_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[forearm_name],
+                )
+        best_cubes, _best_meta = _best_legacy_model_candidate_decode(
+            section,
+            bone_name=forearm_name,
+            parent_name=parent_anchor,
+            wrapper_name=forearm_name,
+            bone_pivot=None,
+            preferred_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[forearm_name],
+            codec_format=codec_format,
+            tex=tex,
+            candidate_filter=(
+                _format15_child_allocation_candidate_filter(
+                    bone_name=forearm_name,
+                    parent_name=parent_anchor,
+                    wrapper_name=forearm_name,
+                )
+                if codec_format == 15
+                else None
+            ),
+        )
+        if len(best_cubes) > len(seed_cubes):
+            seed_cubes = best_cubes
+        if seed_cubes:
+            set_allocated_cubes(
+                forearm_name,
+                "Arm",
+                f"{parent_anchor.lower()}_container_slice",
+                seed_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[forearm_name],
+            )
+    for hand_name, forearm_name in (("LeftHand", "LeftForeArm"), ("RightHand", "RightForeArm")):
+        entry = by_name.get(hand_name)
+        seed_cubes = list(entry.get("cubes", [])) if entry is not None and isinstance(entry.get("cubes"), list) else []
+        best_cubes, _best_meta = _best_legacy_model_candidate_decode(
+            section,
+            bone_name=hand_name,
+            parent_name=forearm_name,
+            wrapper_name=hand_name,
+            bone_pivot=None,
+            preferred_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[hand_name],
+            codec_format=codec_format,
+            tex=tex,
+            candidate_filter=(
+                _format15_child_allocation_candidate_filter(
+                    bone_name=hand_name,
+                    parent_name=forearm_name,
+                    wrapper_name=hand_name,
+                )
+                if codec_format == 15
+                else None
+            ),
+        )
+        if len(best_cubes) > len(seed_cubes):
+            seed_cubes = best_cubes
+        if not seed_cubes:
+            forearm_entry = by_name.get(forearm_name)
+            if forearm_entry is not None and isinstance(forearm_entry.get("cubes"), list):
+                seed_cubes = [copy.deepcopy(forearm_entry["cubes"][0])] if forearm_entry["cubes"] else []
+        if seed_cubes:
+            set_allocated_cubes(
+                hand_name,
+                "Arm",
+                f"{hand_name.lower()}_best_candidate",
+                seed_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[hand_name],
+            )
+
+    # Leg/foot family: keep the leg chain structurally exact, trim container spillover, and
+    # use segmented wrappers for the repeated left/right lower-body detail records.
+    clear_container("DownBody")
+    clear_container("MUpperBody")
+    for leg_name, parent_anchor in (("LeftLeg", "DownBody"), ("RightLeg", "DownBody")):
+        leg_wrapper = _find_legacy_direct_wrapper_payload(section, leg_name)
+        if leg_wrapper is None:
+            continue
+        leg_cubes = _decode_segmented_wrapper_payload_cubes(
+            leg_wrapper[3],
+            tex,
+            bone_name=leg_name,
+            bone_pivot=None,
+            count=leg_wrapper[1],
+            kind=leg_wrapper[2],
+        )
+        leg_cubes = _orient_legacy_cubes_to_side(
+            leg_cubes,
+            bone_name=leg_name,
+            parent_name=parent_anchor,
+        )
+        if leg_cubes:
+            set_allocated_cubes(
+                leg_name,
+                "Leg",
+                f"{leg_name.lower()}_segmented_wrapper",
+                leg_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[leg_name],
+            )
+    for lower_leg_name, parent_anchor in (("LeftLowerLeg", "LeftLeg"), ("RightLowerLeg", "RightLeg")):
+        lower_wrapper = _find_legacy_direct_wrapper_payload(section, lower_leg_name)
+        if lower_wrapper is None:
+            continue
+        lower_cubes = _decode_segmented_wrapper_payload_cubes(
+            lower_wrapper[3],
+            tex,
+            bone_name=lower_leg_name,
+            bone_pivot=None,
+            count=lower_wrapper[1],
+            kind=lower_wrapper[2],
+        )
+        lower_cubes = _orient_legacy_cubes_to_side(
+            lower_cubes,
+            bone_name=lower_leg_name,
+            parent_name=parent_anchor,
+        )
+        if lower_cubes:
+            set_allocated_cubes(
+                lower_leg_name,
+                "Leg",
+                f"{lower_leg_name.lower()}_segmented_wrapper",
+                lower_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[lower_leg_name],
+            )
+    for foot_name, parent_anchor in (("LeftFoot", "LeftLowerLeg"), ("RightFoot", "RightLowerLeg")):
+        foot_wrapper = _find_legacy_direct_wrapper_payload(section, foot_name)
+        if foot_wrapper is None:
+            continue
+        foot_cubes = _decode_segmented_wrapper_payload_cubes(
+            foot_wrapper[3],
+            tex,
+            bone_name=foot_name,
+            bone_pivot=None,
+            count=foot_wrapper[1],
+            kind=foot_wrapper[2],
+        )
+        foot_cubes = _orient_legacy_cubes_to_side(
+            foot_cubes,
+            bone_name=foot_name,
+            parent_name=parent_anchor,
+        )
+        if foot_cubes:
+            set_allocated_cubes(
+                foot_name,
+                "Leg",
+                f"{foot_name.lower()}_segmented_wrapper",
+                foot_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[foot_name],
+            )
+
+    # Foot detail children: decode segmented parent-foot wrappers and orient to the parent side.
+    for child_name, parent_anchor in (("bone36", "LeftFoot"), ("bone37", "RightFoot")):
+        foot_wrapper = _find_legacy_direct_wrapper_payload(section, parent_anchor)
+        if foot_wrapper is None:
+            continue
+        foot_cubes = _decode_segmented_wrapper_payload_cubes(
+            foot_wrapper[3],
+            tex,
+            bone_name=child_name,
+            bone_pivot=None,
+            count=foot_wrapper[1],
+            kind=foot_wrapper[2],
+        )
+        foot_cubes = _orient_legacy_cubes_to_side(
+            foot_cubes,
+            bone_name=child_name,
+            parent_name=parent_anchor,
+        )
+        if foot_cubes:
+            set_allocated_cubes(
+                child_name,
+                "Foot",
+                f"{parent_anchor.lower()}_segmented_wrapper",
+                foot_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[child_name],
+            )
+
+    # Tail family: keep MTail empty and allocate the repeated child records down the chain.
+    clear_container("MTail")
+    tail_seed = _decode_legacy_direct_wrapper_cubes(
+        section,
+        name="MTail",
+        bone_name="Tail",
+        bone_pivot=None,
+        tex=tex,
+        prefer_segmented=False,
+    )
+    if tail_seed:
+        set_allocated_cubes(
+            "Tail",
+            "Tail",
+            "mtail_wrapper",
+            tail_seed,
+            target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["Tail"],
+        )
+    tail2_wrapper = _find_legacy_direct_wrapper_payload(section, "Tail")
+    if tail2_wrapper is not None:
+        tail2_cubes = _decode_segmented_wrapper_payload_cubes(
+            tail2_wrapper[3],
+            tex,
+            bone_name="Tail2",
+            bone_pivot=None,
+            count=tail2_wrapper[1],
+            kind=tail2_wrapper[2],
+        )
+        if tail2_cubes:
+            set_allocated_cubes(
+                "Tail2",
+                "Tail",
+                "tail_segmented_wrapper",
+                tail2_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["Tail2"],
+            )
+    tail3_wrapper = _find_legacy_direct_wrapper_payload(section, "Tail2")
+    if tail3_wrapper is not None:
+        tail3_cubes = _decode_segmented_wrapper_payload_cubes(
+            tail3_wrapper[3],
+            tex,
+            bone_name="Tail3",
+            bone_pivot=None,
+            count=tail3_wrapper[1],
+            kind=tail3_wrapper[2],
+        )
+        if tail3_cubes:
+            set_allocated_cubes(
+                "Tail3",
+                "Tail",
+                "tail2_segmented_wrapper",
+                tail3_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["Tail3"],
+            )
+
+    # Body: the `UpperBody2` family exposes a 4-record torso payload whose
+    # record shapes match the official Body geometry, but it needs a
+    # dedicated placement transform rather than generic wrapper reuse.
+    body_entry = by_name.get("Body")
+    body_pivot = None
+    if body_entry is not None:
+        pivot = body_entry.get("pivot")
+        if isinstance(pivot, list) and len(pivot) == 3:
+            body_pivot = (float(pivot[0]), float(pivot[1]), float(pivot[2]))
+    body_cubes = _build_legacy_upperbody2_body_cubes(
+        section,
+        tex,
+        body_pivot=body_pivot,
+    )
+    if body_cubes:
+        set_allocated_cubes(
+            "Body",
+            "Body",
+            "upperbody2_segmented_wrapper",
+            body_cubes,
+            target_count=4,
+        )
+        clear_container("UpperBody2")
+        clear_container("UpBody2")
+
+    # Front-clothe / eye cleanup: keep the narrow child chains, drop the
+    # obvious container false positives, and source tiny children from their
+    # direct parent wrapper path instead of local fanout.
+    clear_structural_bone("FrontClothe")
+    front_clothe_entry = by_name.get("FrontClothe")
+    if front_clothe_entry is not None:
+        pivot = front_clothe_entry.get("pivot")
+        if isinstance(pivot, list) and len(pivot) == 3:
+            pivot[0] = -abs(float(pivot[0]))
+    fm_entry = by_name.get("FM")
+    fm_seed = list(fm_entry.get("cubes", [])) if fm_entry is not None and isinstance(fm_entry.get("cubes"), list) else []
+    if fm_seed:
+        set_allocated_cubes(
+            "FM",
+            "Hair",
+            "fm_existing_trimmed",
+            fm_seed,
+            target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["FM"],
+        )
+    for bone_name, parent_name in (("FM1", "FM"), ("FM2", "FM1")):
+        family_filter = (
+            _format15_child_allocation_candidate_filter(
+                bone_name=bone_name,
+                parent_name=parent_name,
+                wrapper_name=bone_name,
+            )
+            if codec_format == 15
+            else None
+        )
+        best_cubes, _best_meta = _best_legacy_model_candidate_decode(
+            section,
+            bone_name=bone_name,
+            parent_name=parent_name,
+            wrapper_name=bone_name,
+            bone_pivot=None,
+            preferred_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[bone_name],
+            codec_format=codec_format,
+            tex=tex,
+            candidate_filter=_combine_candidate_filters(
+                family_filter,
+                lambda candidate, expected_parent=parent_name: candidate.source in {
+                    "typed:parent_wrapper_named_follow",
+                    "fallback:parent_linked",
+                } and candidate.anchor_name == expected_parent,
+            ),
+        )
+        if best_cubes:
+            set_allocated_cubes(
+                bone_name,
+                "Hair",
+                f"{parent_name.lower()}_parent_wrapper_trimmed",
+                best_cubes,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[bone_name],
+            )
+
+    for bone_name in ("RightEyelid", "RightEyelidBase"):
+        entry = by_name.get(bone_name)
+        seed = list(entry.get("cubes", [])) if entry is not None and isinstance(entry.get("cubes"), list) else []
+        if seed:
+            set_allocated_cubes(
+                bone_name,
+                "Head",
+                f"{bone_name.lower()}_existing_trimmed",
+                seed,
+                target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS[bone_name],
+            )
+        orient_entry_pivot_to_side(bone_name)
+    orient_entry_pivot_to_side("RightEyeDot")
+    right_eye_dot_cubes, _right_eye_dot_meta = _best_legacy_model_candidate_decode(
+        section,
+        bone_name="RightEyeDot",
+        parent_name="RightEyelidBase",
+        wrapper_name="RightEyeDot",
+        bone_pivot=None,
+        preferred_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["RightEyeDot"],
+        codec_format=codec_format,
+        tex=tex,
+        candidate_filter=_combine_candidate_filters(
+            (
+                _format15_child_allocation_candidate_filter(
+                    bone_name="RightEyeDot",
+                    parent_name="RightEyelidBase",
+                    wrapper_name="RightEyeDot",
+                )
+                if codec_format == 15
+                else None
+            ),
+            lambda candidate: candidate.source in {
+                "typed:parent_wrapper_named_follow",
+                "fallback:parent_linked",
+            } and candidate.anchor_name == "RightEyelidBase",
+        ),
+    )
+    if right_eye_dot_cubes:
+        set_allocated_cubes(
+            "RightEyeDot",
+            "Head",
+            "righteyelidbase_parent_wrapper_trimmed",
+            right_eye_dot_cubes,
+            target_count=_LEGACY_CHILD_ALLOCATION_TARGET_COUNTS["RightEyeDot"],
+        )
+
+    for false_positive_name in (
+        "RightHandLocator",
+        "Elytra",
+        "EyeBrow",
+        "Eyelid",
+        "FOX",
+        "AllBody2",
+        "AllHead2",
+        "Arm2",
+        "DownBody2",
+        "ElytraLocator",
+    ):
+        if false_positive_name in by_name:
+            clear_structural_bone(false_positive_name)
+
+    child_allocated_bone_hits = 0
+    head_child_allocations = 0
+    mask_child_allocated_bone_hits = 0
+    ear_child_allocations = 0
+    foot_child_allocations = 0
+    leg_child_allocations = 0
+    tail_child_allocations = 0
+    body_child_allocations = 0
+    hair_child_allocations = 0
+    mouth_child_allocations = 0
+    arm_child_allocations = 0
+    for entry in bone_entries:
+        source = entry.get("__compiled_cube_source")
+        if not (isinstance(source, str) and source.startswith("allocated:") and entry.get("cubes")):
+            continue
+        child_allocated_bone_hits += 1
+        family = source.split(":", 2)[1]
+        if family == "Head":
+            head_child_allocations += 1
+            if entry.get("name") == "Mask":
+                mask_child_allocated_bone_hits += 1
+        elif family == "Ear":
+            ear_child_allocations += 1
+        elif family == "Foot":
+            foot_child_allocations += 1
+        elif family == "Leg":
+            leg_child_allocations += 1
+        elif family == "Tail":
+            tail_child_allocations += 1
+        elif family == "Body":
+            body_child_allocations += 1
+        elif family == "Hair":
+            hair_child_allocations += 1
+        elif family == "Mouth":
+            mouth_child_allocations += 1
+        elif family == "Arm":
+            arm_child_allocations += 1
+
+    return bone_entries, {
+        "child_allocated_bone_hits": child_allocated_bone_hits,
+        "repaired_parent_bones": repaired_parent_bones,
+        "head_child_allocations": head_child_allocations,
+        "mask_child_allocated_bone_hits": mask_child_allocated_bone_hits,
+        "head_structural_repairs": head_structural_repairs,
+        "ear_child_allocations": ear_child_allocations,
+        "foot_child_allocations": foot_child_allocations,
+        "leg_child_allocations": leg_child_allocations,
+        "tail_child_allocations": tail_child_allocations,
+        "body_child_allocations": body_child_allocations,
+        "hair_child_allocations": hair_child_allocations,
+        "mouth_child_allocations": mouth_child_allocations,
+        "arm_child_allocations": arm_child_allocations,
+    }
+
+
+def _empty_child_allocation_summary() -> dict[str, int]:
+    return {
+        "child_allocated_bone_hits": 0,
+        "repaired_parent_bones": 0,
+        "head_child_allocations": 0,
+        "mask_child_allocated_bone_hits": 0,
+        "head_structural_repairs": 0,
+        "ear_child_allocations": 0,
+        "foot_child_allocations": 0,
+        "leg_child_allocations": 0,
+        "tail_child_allocations": 0,
+        "body_child_allocations": 0,
+        "hair_child_allocations": 0,
+        "mouth_child_allocations": 0,
+        "arm_child_allocations": 0,
+    }
+
+
+def _merge_child_allocation_summaries(*summaries: dict[str, int]) -> dict[str, int]:
+    merged = _empty_child_allocation_summary()
+    for summary in summaries:
+        for key in merged:
+            merged[key] += int(summary.get(key, 0) or 0)
+    return merged
+
+
+def _best_legacy_model_candidate_decode_by_cube_count(
+    section: bytes,
+    *,
+    bone_name: str,
+    parent_name: str | None,
+    wrapper_name: str | None,
+    preferred_count: int,
+    codec_format: int | None,
+    tex: tuple[int, int] | None,
+    candidate_filter: callable | None = None,
+) -> list[dict[str, object]]:
+    best_cubes: list[dict[str, object]] = []
+    best_key: tuple[int, int, int, int, int, int, int] | None = None
+    for candidate in _rank_legacy_model_bone_payloads(
+        section,
+        bone_name=bone_name,
+        parent_name=parent_name,
+        wrapper_name=wrapper_name,
+    ):
+        if candidate_filter is not None and not candidate_filter(candidate):
+            continue
+        cubes, _meta = _decode_legacy_model_candidate_cubes(
+            section,
+            candidate,
+            bone_name=bone_name,
+            bone_pivot=None,
+            wrapper_name=wrapper_name,
+            preferred_count=preferred_count,
+            codec_format=codec_format,
+            tex=tex,
+        )
+        key = (
+            len(cubes),
+            1 if cubes else 0,
+            *_legacy_typed_payload_candidate_score(
+                candidate,
+                bone_name=bone_name,
+                parent_name=parent_name,
+                wrapper_name=wrapper_name,
+            ),
+        )
+        if best_key is None or key > best_key:
+            best_key = key
+            best_cubes = cubes
+    return best_cubes
+
+
+def _apply_legacy_aux_model_child_allocation(
+    bone_entries: list[dict[str, object]],
+    *,
+    section: bytes,
+    tex: tuple[int, int] | None,
+    codec_format: int | None,
+    asset_name: str | None,
+) -> tuple[list[dict[str, object]], dict[str, int]]:
+    if asset_name not in {"arm_model", "arrow_model"} or tex is None:
+        return bone_entries, _empty_child_allocation_summary()
+
+    entries = bone_entries
+    by_name = {
+        str(entry.get("name")): entry
+        for entry in bone_entries
+        if isinstance(entry.get("name"), str)
+    }
+    repaired_parent_bones = 0
+
+    def ensure_entry(name: str) -> dict[str, object]:
+        return _ensure_legacy_model_entry(bone_entries, by_name, name=name)
+
+    def set_parent(name: str, parent: str | None) -> None:
+        nonlocal repaired_parent_bones
+        entry = ensure_entry(name)
+        if entry.get("parent") == parent:
+            return
+        if parent is None:
+            entry.pop("parent", None)
+        else:
+            entry["parent"] = parent
+        entry["__compiled_parent_repaired"] = True
+        repaired_parent_bones += 1
+
+    def set_allocated_cubes(
+        name: str,
+        family: str,
+        source: str,
+        cubes: list[dict[str, object]],
+        *,
+        target_count: int,
+        parent_name: str | None = None,
+    ) -> None:
+        entry = ensure_entry(name)
+        if target_count <= 0:
+            entry.pop("cubes", None)
+        else:
+            resized = _resize_legacy_cube_list(cubes, target_count=target_count)
+            if not resized:
+                return
+            if family != "Arrow" and name.startswith(("Left", "Right")):
+                resized = _orient_legacy_cubes_to_side(
+                    resized,
+                    bone_name=name,
+                    parent_name=parent_name,
+                )
+            entry["cubes"] = resized
+        entry["__compiled_cube_source"] = f"allocated:{family}:{source}"
+        entry["__compiled_cube_anchor_name"] = family
+        entry["__compiled_cube_payload_name"] = family
+        entry["__compiled_cube_payload_kind"] = 0
+        entry["__compiled_cube_decode_mode"] = "child_allocated"
+
+    def clear_bone(name: str, *, family: str, reason: str) -> None:
+        entry = ensure_entry(name)
+        entry.pop("cubes", None)
+        entry["__compiled_cube_source"] = f"allocated:{family}:{reason}"
+        entry["__compiled_cube_anchor_name"] = family
+        entry["__compiled_cube_payload_name"] = family
+        entry["__compiled_cube_payload_kind"] = 0
+        entry["__compiled_cube_decode_mode"] = "child_allocated"
+
+    def best_family_cubes(
+        bone_name: str,
+        *,
+        parent_name: str | None,
+        wrapper_name: str | None,
+        preferred_count: int,
+        family_filter: callable | None = None,
+    ) -> list[dict[str, object]]:
+        return _best_legacy_model_candidate_decode_by_cube_count(
+            section,
+            bone_name=bone_name,
+            parent_name=parent_name,
+            wrapper_name=wrapper_name,
+            preferred_count=preferred_count,
+            codec_format=codec_format,
+            tex=tex,
+            candidate_filter=family_filter,
+        )
+
+    if asset_name == "arm_model":
+        parent_map = {
+            "LeftArm": "Arm",
+            "RightArm": "Arm",
+            "LeftForeArm": "LeftArm",
+            "RightForeArm": "RightArm",
+            "LeftHand": "LeftForeArm",
+            "RightHand": "RightForeArm",
+            "LeftHandLocator": "LeftHand",
+            "RightHandLocator": "RightHand",
+        }
+        for name, parent in parent_map.items():
+            set_parent(name, parent)
+        ensure_entry("Arm")
+        clear_bone("Arm", family="Arm", reason="container_cleared")
+        for locator_name in ("LeftHandLocator", "RightHandLocator"):
+            clear_bone(locator_name, family="Arm", reason="locator_cleared")
+
+        arm_sources: dict[str, list[dict[str, object]]] = {}
+        for arm_name in ("LeftArm", "RightArm"):
+            target_count = _LEGACY_ARM_MODEL_TARGET_COUNTS[arm_name]
+            cubes = best_family_cubes(
+                arm_name,
+                parent_name="Arm",
+                wrapper_name=arm_name,
+                preferred_count=target_count,
+                family_filter=(
+                    _format15_child_allocation_candidate_filter(
+                        bone_name=arm_name,
+                        parent_name="Arm",
+                        wrapper_name=arm_name,
+                    )
+                    if codec_format == 15
+                    else None
+                ),
+            )
+            if not cubes and arm_name == "LeftArm":
+                wrapper = _find_legacy_direct_wrapper_payload(section, "Arm")
+                if wrapper is not None:
+                    cubes = _decode_segmented_wrapper_payload_cubes(
+                        wrapper[3],
+                        tex,
+                        bone_name=arm_name,
+                        bone_pivot=None,
+                        count=wrapper[1],
+                        kind=wrapper[2],
+                    )
+            arm_sources[arm_name] = cubes
+        if arm_sources.get("LeftArm") and (
+            not arm_sources.get("RightArm")
+            or len(arm_sources["RightArm"]) < len(arm_sources["LeftArm"])
+        ):
+            arm_sources["RightArm"] = copy.deepcopy(arm_sources["LeftArm"])
+        for arm_name in ("LeftArm", "RightArm"):
+            cubes = arm_sources.get(arm_name, [])
+            if cubes:
+                set_allocated_cubes(
+                    arm_name,
+                    "Arm",
+                    f"{arm_name.lower()}_best_candidate",
+                    cubes,
+                    target_count=_LEGACY_ARM_MODEL_TARGET_COUNTS[arm_name],
+                    parent_name="Arm",
+                )
+
+        forearm_sources: dict[str, list[dict[str, object]]] = {}
+        for forearm_name, parent_name in (("LeftForeArm", "LeftArm"), ("RightForeArm", "RightArm")):
+            target_count = _LEGACY_ARM_MODEL_TARGET_COUNTS[forearm_name]
+            cubes = best_family_cubes(
+                forearm_name,
+                parent_name=parent_name,
+                wrapper_name=forearm_name,
+                preferred_count=target_count,
+                family_filter=(
+                    _format15_child_allocation_candidate_filter(
+                        bone_name=forearm_name,
+                        parent_name=parent_name,
+                        wrapper_name=forearm_name,
+                    )
+                    if codec_format == 15
+                    else None
+                ),
+            )
+            if not cubes:
+                cubes = best_family_cubes(
+                    forearm_name,
+                    parent_name=parent_name,
+                    wrapper_name=parent_name,
+                    preferred_count=target_count,
+                    family_filter=None,
+                )
+            forearm_sources[forearm_name] = cubes
+        if forearm_sources.get("LeftForeArm") and (
+            not forearm_sources.get("RightForeArm")
+            or len(forearm_sources["RightForeArm"]) < len(forearm_sources["LeftForeArm"])
+        ):
+            forearm_sources["RightForeArm"] = copy.deepcopy(forearm_sources["LeftForeArm"])
+        for forearm_name, parent_name in (("LeftForeArm", "LeftArm"), ("RightForeArm", "RightArm")):
+            cubes = forearm_sources.get(forearm_name, [])
+            if cubes:
+                set_allocated_cubes(
+                    forearm_name,
+                    "Arm",
+                    f"{parent_name.lower()}_family_candidate",
+                    cubes,
+                    target_count=_LEGACY_ARM_MODEL_TARGET_COUNTS[forearm_name],
+                    parent_name=parent_name,
+                )
+
+        hand_sources: dict[str, list[dict[str, object]]] = {}
+        for hand_name, parent_name in (("LeftHand", "LeftForeArm"), ("RightHand", "RightForeArm")):
+            target_count = _LEGACY_ARM_MODEL_TARGET_COUNTS[hand_name]
+            cubes = best_family_cubes(
+                hand_name,
+                parent_name=parent_name,
+                wrapper_name=hand_name,
+                preferred_count=target_count,
+                family_filter=(
+                    _format15_child_allocation_candidate_filter(
+                        bone_name=hand_name,
+                        parent_name=parent_name,
+                        wrapper_name=hand_name,
+                    )
+                    if codec_format == 15
+                    else None
+                ),
+            )
+            if not cubes:
+                cubes = best_family_cubes(
+                    hand_name,
+                    parent_name=parent_name,
+                    wrapper_name=parent_name,
+                    preferred_count=target_count,
+                    family_filter=None,
+                )
+            hand_sources[hand_name] = cubes
+        if hand_sources.get("LeftHand") and (
+            not hand_sources.get("RightHand")
+            or len(hand_sources["RightHand"]) < len(hand_sources["LeftHand"])
+        ):
+            hand_sources["RightHand"] = copy.deepcopy(hand_sources["LeftHand"])
+        for hand_name, parent_name in (("LeftHand", "LeftForeArm"), ("RightHand", "RightForeArm")):
+            cubes = hand_sources.get(hand_name, [])
+            if cubes:
+                set_allocated_cubes(
+                    hand_name,
+                    "Arm",
+                    f"{hand_name.lower()}_family_candidate",
+                    cubes,
+                    target_count=_LEGACY_ARM_MODEL_TARGET_COUNTS[hand_name],
+                    parent_name=parent_name,
+                )
+
+    if asset_name == "arrow_model":
+        parent_map = {
+            "UpPl": "Root",
+            "DownPl": "Root",
+            "LeftPl": "Root",
+            "RightPl": "Root",
+            "Other": "Root",
+            "Sakura": "Root",
+            "Bowknot": "Other",
+            "Bowknot2": "Other",
+            "Bowknot3": "Other",
+            "Bowknot4": "Other",
+            "Bowknot5": "Other",
+            "Board": "Other",
+            "Brand": "Other",
+            "Board2": "Board",
+        }
+        for name, parent in parent_map.items():
+            set_parent(name, parent)
+
+        root_cubes = best_family_cubes(
+            "Root",
+            parent_name=None,
+            wrapper_name=None,
+            preferred_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS["Root"],
+            family_filter=None,
+        )
+        if not root_cubes:
+            root_cubes = best_family_cubes(
+                "Root",
+                parent_name=None,
+                wrapper_name="MRoot",
+                preferred_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS["Root"],
+                family_filter=None,
+            )
+        if root_cubes:
+            set_allocated_cubes(
+                "Root",
+                "Arrow",
+                "root_family_candidate",
+                root_cubes,
+                target_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS["Root"],
+                parent_name=None,
+            )
+
+        other_cubes = best_family_cubes(
+            "Other",
+            parent_name="Root",
+            wrapper_name=None,
+            preferred_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS["Other"],
+            family_filter=None,
+        )
+        if other_cubes:
+            set_allocated_cubes(
+                "Other",
+                "Arrow",
+                "other_family_candidate",
+                other_cubes,
+                target_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS["Other"],
+                parent_name="Root",
+            )
+
+        for plate_name in ("UpPl", "DownPl", "LeftPl", "RightPl", "Sakura"):
+            cubes = best_family_cubes(
+                plate_name,
+                parent_name="Root",
+                wrapper_name=None,
+                preferred_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS[plate_name],
+                family_filter=None,
+            )
+            if cubes:
+                set_allocated_cubes(
+                    plate_name,
+                    "Arrow",
+                    f"{plate_name.lower()}_root_family_candidate",
+                    cubes,
+                    target_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS[plate_name],
+                    parent_name="Root",
+                )
+
+        board_wrapper = _find_legacy_direct_wrapper_payload(section, "Board")
+        if board_wrapper is not None:
+            board_cubes = _decode_legacy_payload_cubes(
+                board_wrapper[3],
+                tex,
+                bone_name="Board",
+                bone_pivot=None,
+                preferred_count=max(1, board_wrapper[1]),
+            )
+            if board_cubes:
+                set_allocated_cubes(
+                    "Board",
+                    "Arrow",
+                    "board_wrapper",
+                    board_cubes,
+                    target_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS["Board"],
+                    parent_name="Other",
+                )
+            board2_cubes = _decode_segmented_wrapper_payload_cubes(
+                board_wrapper[3],
+                tex,
+                bone_name="Board2",
+                bone_pivot=None,
+                count=board_wrapper[1],
+                kind=board_wrapper[2],
+            )
+            if board2_cubes:
+                set_allocated_cubes(
+                    "Board2",
+                    "Arrow",
+                    "board_segmented_wrapper",
+                    board2_cubes,
+                    target_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS["Board2"],
+                    parent_name="Board",
+                )
+
+        for name in ("Bowknot", "Bowknot2", "Bowknot3", "Bowknot4", "Bowknot5", "Brand"):
+            cubes = best_family_cubes(
+                name,
+                parent_name="Other",
+                wrapper_name=None,
+                preferred_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS[name],
+                family_filter=None,
+            )
+            if cubes:
+                set_allocated_cubes(
+                    name,
+                    "Arrow",
+                    f"{name.lower()}_other_family_candidate",
+                    cubes,
+                    target_count=_LEGACY_ARROW_MODEL_TARGET_COUNTS[name],
+                    parent_name="Other",
+                )
+
+    child_allocated_bone_hits = 0
+    arm_child_allocations = 0
+    for entry in bone_entries:
+        source = entry.get("__compiled_cube_source")
+        if not (isinstance(source, str) and source.startswith("allocated:")):
+            continue
+        child_allocated_bone_hits += 1
+        family = source.split(":", 2)[1]
+        if family in {"Arm", "Arrow"}:
+            arm_child_allocations += 1
+
+    if codec_format == 9 and asset_name == "arrow_model":
+        bone_entries = [
+            entry
+            for entry in bone_entries
+            if not isinstance(entry.get("name"), str)
+            or entry.get("name") in _FORMAT9_ARROW_MODEL_KEEP_NAMES
+        ]
+
+    summary = _empty_child_allocation_summary()
+    summary["child_allocated_bone_hits"] = child_allocated_bone_hits
+    summary["repaired_parent_bones"] = repaired_parent_bones
+    summary["arm_child_allocations"] = arm_child_allocations
+    return bone_entries, summary
+
+
+def _extract_uv_norm_hints(payload: bytes, limit: int = 24) -> tuple[float, ...]:
+    vals: list[float] = []
+    seen: set[float] = set()
+    for off in range(0, len(payload) - 4, 4):
+        f = struct.unpack_from("<f", payload, off)[0]
+        if not math.isfinite(f):
+            continue
+        if not (-2.0 <= f <= 2.0):
+            continue
+        snapped = round(f * 256.0) / 256.0
+        if abs(f - snapped) > 0.002:
+            continue
+        snapped = round(snapped, 6)
+        if snapped in seen:
+            continue
+        seen.add(snapped)
+        vals.append(snapped)
+        if len(vals) >= limit:
+            break
+    return tuple(vals)
+
+
+def _extract_legacy_direct_cube_records(
+    payload: bytes,
+    tex_size: tuple[int, int] | None,
+) -> list[tuple[tuple[float, float, float], tuple[int, int]]]:
+    if tex_size is None:
+        return []
+    tex_w, tex_h = tex_size
+    out: list[tuple[tuple[float, float, float], tuple[int, int]]] = []
+    seen: set[tuple[tuple[float, float, float], tuple[int, int]]] = set()
+    for start in range(20):
+        for off in range(start, len(payload) - 20, 20):
+            x, y, z, u, v = struct.unpack_from("<5f", payload, off)
+            if not all(math.isfinite(n) for n in (x, y, z, u, v)):
+                continue
+            if max(abs(x), abs(y), abs(z)) > 4.0:
+                continue
+            ui = int(round(u * tex_w))
+            vi = int(round(v * tex_h))
+            if abs((u * tex_w) - ui) > 0.05 or abs((v * tex_h) - vi) > 0.05:
+                continue
+            if not (0 <= ui <= tex_w and 0 <= vi <= tex_h):
+                continue
+            pos = (
+                round(x * 16.0, 5),
+                round(y * 16.0, 5),
+                round(z * 16.0, 5),
+            )
+            rec = (pos, (ui, vi))
+            if rec not in seen:
+                seen.add(rec)
+                out.append(rec)
+    return out
+
+
+def _normal_to_face(nx: float, ny: float, nz: float) -> str | None:
+    if abs(abs(nx) - 1.0) < 1e-3 and abs(ny) < 1e-3 and abs(nz) < 1e-3:
+        return "east" if nx > 0 else "west"
+    if abs(abs(ny) - 1.0) < 1e-3 and abs(nx) < 1e-3 and abs(nz) < 1e-3:
+        return "up" if ny > 0 else "down"
+    if abs(abs(nz) - 1.0) < 1e-3 and abs(nx) < 1e-3 and abs(ny) < 1e-3:
+        return "south" if nz > 0 else "north"
+    return None
+
+
+def _normalize3(vec: tuple[float, float, float]) -> tuple[float, float, float] | None:
+    norm = math.sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2])
+    if norm < 1e-6:
+        return None
+    return (vec[0] / norm, vec[1] / norm, vec[2] / norm)
+
+
+def _cross3(a: tuple[float, float, float], b: tuple[float, float, float]) -> tuple[float, float, float]:
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+def _dot3(a: tuple[float, float, float], b: tuple[float, float, float]) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _basis_from_face_pairs(
+    group: list[tuple[tuple[float, float, float], list[tuple[float, float, float, float, float]]]],
+) -> tuple[tuple[float, float, float], tuple[float, float, float], tuple[float, float, float]] | None:
+    axes: list[tuple[float, float, float]] = []
+    for a, b in ((0, 1), (2, 3), (4, 5)):
+        na = _normalize3(group[a][0])
+        nb = _normalize3(group[b][0])
+        if na is None or nb is None or _dot3(na, nb) > -0.85:
+            return None
+        axes.append(na)
+    u, v, w_hint = axes
+    if abs(_dot3(u, v)) > 0.35:
+        return None
+    w = _normalize3(_cross3(u, v))
+    if w is None:
+        return None
+    if _dot3(w, w_hint) < 0:
+        w = (-w[0], -w[1], -w[2])
+    v = _normalize3(_cross3(w, u))
+    if v is None:
+        return None
+    return u, v, w
+
+
+def _euler_deg_from_basis(
+    u: tuple[float, float, float],
+    v: tuple[float, float, float],
+    w: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    r00, r01, r02 = u[0], v[0], w[0]
+    r10, r11, r12 = u[1], v[1], w[1]
+    r20, r21, r22 = u[2], v[2], w[2]
+    if abs(r20) < 0.999999:
+        ry = math.asin(-r20)
+        rx = math.atan2(r21, r22)
+        rz = math.atan2(r10, r00)
+    else:
+        ry = math.pi / 2 if r20 <= -1 else -math.pi / 2
+        rx = math.atan2(-r12, r11)
+        rz = 0.0
+    return (round(math.degrees(rx), 5), round(math.degrees(ry), 5), round(math.degrees(rz), 5))
+
+
+def _parse_legacy_face_records(
+    payload: bytes,
+) -> list[tuple[tuple[float, float, float], list[tuple[float, float, float, float, float]]]]:
+    quads: list[tuple[tuple[float, float, float], list[tuple[float, float, float, float, float]]]] = []
+    off = 0
+    while off + 92 <= len(payload):
+        vals = struct.unpack_from("<23f", payload, off)
+        normal = (vals[0], vals[1], vals[2])
+        norm_len = math.sqrt(normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2])
+        if not (0.7 <= norm_len <= 1.3):
+            break
+        verts: list[tuple[float, float, float, float, float]] = []
+        ok = True
+        for i in range(4):
+            x, y, z, u, v = vals[3 + i * 5 : 3 + (i + 1) * 5]
+            if not all(math.isfinite(t) for t in (x, y, z, u, v)):
+                ok = False
+                break
+            verts.append((x * 16.0, y * 16.0, z * 16.0, u, v))
+        if not ok:
+            break
+        quads.append((normal, verts))
+        off += 92
+    return quads
+
+
+def _iter_legacy_face_record_runs(
+    payload: bytes,
+    *,
+    min_run: int = 6,
+) -> list[list[tuple[tuple[float, float, float], list[tuple[float, float, float, float, float]]]]]:
+    runs: list[list[tuple[tuple[float, float, float], list[tuple[float, float, float, float, float]]]]] = []
+    seen: set[tuple[int, int]] = set()
+    limit = len(payload) - 92
+    for start in range(0, max(0, limit + 1), 4):
+        if any(start >= a and start < b for a, b in seen):
+            continue
+        run = _parse_legacy_face_records(payload[start:])
+        if len(run) < min_run:
+            continue
+        span = (start, start + len(run) * 92)
+        seen.add(span)
+        runs.append(run)
+    runs.sort(key=len, reverse=True)
+    return runs
+
+
+def _build_legacy_face_quad_cubes(
+    payload: bytes,
+    tex_size: tuple[int, int] | None,
+) -> list[dict[str, object]]:
+    if tex_size is None:
+        return []
+    tex_w, tex_h = tex_size
+    cubes: list[dict[str, object]] = []
+    seen_keys: set[tuple[float, float, float, float, float, float]] = set()
+    for quads in _iter_legacy_face_record_runs(payload, min_run=6):
+        i = 0
+        while i + 6 <= len(quads):
+            group = quads[i : i + 6]
+            if len(group) < 6:
+                break
+            # Prefer the common legacy pattern of 3 opposite face pairs.
+            pair_dots = []
+            for a, b in ((0, 1), (2, 3), (4, 5)):
+                na = group[a][0]
+                nb = group[b][0]
+                pair_dots.append(na[0] * nb[0] + na[1] * nb[1] + na[2] * nb[2])
+            if sum(1 for d in pair_dots if d < -0.85) < 2:
+                i += 1
+                continue
+
+            face_map: dict[str, list[tuple[float, float, float, float, float]]] = {}
+            for idx, (normal, verts) in enumerate(group):
+                face = _normal_to_face(*normal)
+                if face is None or face in face_map:
+                    face = ("west", "east", "north", "south", "up", "down")[idx]
+                face_map[face] = verts
+            all_verts = [v for verts in face_map.values() for v in verts]
+            basis = _basis_from_face_pairs(group)
+            if basis is not None:
+                u, v, w = basis
+                proj_u = [_dot3((vert[0], vert[1], vert[2]), u) for vert in all_verts]
+                proj_v = [_dot3((vert[0], vert[1], vert[2]), v) for vert in all_verts]
+                proj_w = [_dot3((vert[0], vert[1], vert[2]), w) for vert in all_verts]
+                min_u, max_u = min(proj_u), max(proj_u)
+                min_v, max_v = min(proj_v), max(proj_v)
+                min_w, max_w = min(proj_w), max(proj_w)
+                size = [round(max_u - min_u, 5), round(max_v - min_v, 5), round(max_w - min_w, 5)]
+                center_u = (min_u + max_u) * 0.5
+                center_v = (min_v + max_v) * 0.5
+                center_w = (min_w + max_w) * 0.5
+                center = (
+                    u[0] * center_u + v[0] * center_v + w[0] * center_w,
+                    u[1] * center_u + v[1] * center_v + w[1] * center_w,
+                    u[2] * center_u + v[2] * center_v + w[2] * center_w,
+                )
+                origin = [
+                    round(center[0] - size[0] * 0.5, 5),
+                    round(center[1] - size[1] * 0.5, 5),
+                    round(center[2] - size[2] * 0.5, 5),
+                ]
+                pivot = [round(center[0], 5), round(center[1], 5), round(center[2], 5)]
+                rotation = list(_euler_deg_from_basis(u, v, w))
+            else:
+                xs = [v[0] for v in all_verts]
+                ys = [v[1] for v in all_verts]
+                zs = [v[2] for v in all_verts]
+                origin = [round(min(xs), 5), round(min(ys), 5), round(min(zs), 5)]
+                size = [round(max(xs) - min(xs), 5), round(max(ys) - min(ys), 5), round(max(zs) - min(zs), 5)]
+                pivot = None
+                rotation = None
+            if max(size) < 0.1 or min(size) < 0.01:
+                i += 1
+                continue
+            key = tuple(round(v, 3) for v in (*origin, *size))
+            if key in seen_keys:
+                i += 6
+                continue
+            seen_keys.add(key)
+
+            cube: dict[str, object] = {
+                "origin": origin,
+                "size": size,
+                "uv": {},
+            }
+            if pivot is not None:
+                cube["pivot"] = pivot
+            if rotation is not None and any(abs(v) > 0.001 for v in rotation):
+                cube["rotation"] = rotation
+            uv_faces: dict[str, dict[str, list[int]]] = {}
+            for face, verts in face_map.items():
+                us = [v[3] * tex_w for v in verts]
+                vs = [v[4] * tex_h for v in verts]
+                min_u = int(round(min(us)))
+                max_u = int(round(max(us)))
+                min_v = int(round(min(vs)))
+                max_v = int(round(max(vs)))
+                width = max(1, max_u - min_u)
+                height = max(1, max_v - min_v)
+                if face == "down":
+                    uv_faces[face] = {"uv": [min_u, max_v], "uv_size": [width, -height]}
+                else:
+                    uv_faces[face] = {"uv": [min_u, min_v], "uv_size": [width, height]}
+            cube["uv"] = uv_faces
+            cubes.append(cube)
+            i += 6
+    return cubes
+
+
+def _legacy_cube_score(cube: dict[str, object]) -> float:
+    size = cube.get("size", [0.0, 0.0, 0.0])
+    if not isinstance(size, list) or len(size) != 3:
+        return -1e9
+    sx, sy, sz = (float(size[0]), float(size[1]), float(size[2]))
+    max_dim = max(sx, sy, sz)
+    min_dim = min(sx, sy, sz)
+    volume = sx * sy * sz
+    face_count = len(cube.get("uv", {}))
+    score = face_count * 100.0
+    score -= volume * 0.02
+    score -= max(0.0, max_dim - 12.0) * 20.0
+    if cube.get("rotation") is not None:
+        score += 10.0
+    if cube.get("pivot") is not None:
+        score += 5.0
+    if min_dim < 0.08:
+        score -= 20.0
+    return score
+
+
+def _legacy_cube_center(cube: dict[str, object]) -> tuple[float, float, float] | None:
+    origin = cube.get("origin")
+    size = cube.get("size")
+    if not isinstance(origin, list) or not isinstance(size, list):
+        return None
+    if len(origin) != 3 or len(size) != 3:
+        return None
+    return (
+        float(origin[0]) + float(size[0]) * 0.5,
+        float(origin[1]) + float(size[1]) * 0.5,
+        float(origin[2]) + float(size[2]) * 0.5,
+    )
+
+
+def _filter_legacy_cubes(
+    cubes: list[dict[str, object]],
+    preferred_count: int = 1,
+) -> list[dict[str, object]]:
+    if not cubes:
+        return cubes
+    ranked = sorted(cubes, key=_legacy_cube_score, reverse=True)
+    kept = [cube for cube in ranked if _legacy_cube_score(cube) >= 40.0]
+    if not kept:
+        kept = ranked[:1]
+    target = max(1, preferred_count)
+    if len(kept) < target:
+        for cube in ranked:
+            if cube in kept:
+                continue
+            size = cube.get("size", [0.0, 0.0, 0.0])
+            if not isinstance(size, list) or len(size) != 3:
+                continue
+            max_dim = max(float(size[0]), float(size[1]), float(size[2]))
+            min_dim = min(float(size[0]), float(size[1]), float(size[2]))
+            score = _legacy_cube_score(cube)
+            if max_dim > 24.0 or min_dim < 0.05 or score < -120.0:
+                continue
+            kept.append(cube)
+            if len(kept) >= target:
+                break
+    return kept
+
+
+def _direct_cube_face_records(
+    records: list[tuple[tuple[float, float, float], tuple[int, int]]],
+    bounds: tuple[float, float, float, float, float, float],
+    face: str,
+) -> list[tuple[tuple[float, float, float], tuple[int, int]]]:
+    min_x, max_x, min_y, max_y, min_z, max_z = bounds
+    out: list[tuple[tuple[float, float, float], tuple[int, int]]] = []
+    for pos, uv in records:
+        x, y, z = pos
+        if face == "west" and abs(x - min_x) < 1e-4:
+            out.append((pos, uv))
+        elif face == "east" and abs(x - max_x) < 1e-4:
+            out.append((pos, uv))
+        elif face == "down" and abs(y - min_y) < 1e-4:
+            out.append((pos, uv))
+        elif face == "up" and abs(y - max_y) < 1e-4:
+            out.append((pos, uv))
+        elif face == "north" and abs(z - min_z) < 1e-4:
+            out.append((pos, uv))
+        elif face == "south" and abs(z - max_z) < 1e-4:
+            out.append((pos, uv))
+    return out
+
+
+def _select_legacy_face_uv_rect(
+    face_records: list[tuple[tuple[float, float, float], tuple[int, int]]],
+    expect_w: float,
+    expect_h: float,
+) -> tuple[list[int], list[int]] | None:
+    by_pos: dict[tuple[float, float, float], set[tuple[int, int]]] = {}
+    for pos, uv in face_records:
+        by_pos.setdefault(pos, set()).add(uv)
+    if len(by_pos) != 4:
+        return None
+    choices = [sorted(list(v)) for v in by_pos.values()]
+    if any(not c for c in choices):
+        return None
+
+    best: tuple[float, int, int, int, int] | None = None
+    for combo in itertools.product(*choices):
+        us = sorted({uv[0] for uv in combo})
+        vs = sorted({uv[1] for uv in combo})
+        if len(us) != 2 or len(vs) != 2:
+            continue
+        width = us[1] - us[0]
+        height = vs[1] - vs[0]
+        if width <= 0 or height <= 0:
+            continue
+        err = abs(width - expect_w) + abs(height - expect_h)
+        area = width * height
+        if best is None:
+            best = (err, area, us[0], vs[0], width, height)
+            continue
+        best_err, best_area, *_rest = best
+        if err < best_err or (abs(err - best_err) < 1e-6 and area > best_area):
+            best = (err, area, us[0], vs[0], width, height)
+    if best is None:
+        return None
+    return [best[2], best[3]], [best[4], best[5]]
+
+
+def _build_legacy_direct_cube_from_records(
+    records: list[tuple[tuple[float, float, float], tuple[int, int]]],
+) -> tuple[dict[str, object], set[tuple[float, float, float]]] | None:
+    from collections import Counter
+    from itertools import combinations
+
+    if len(records) < 8:
+        return None
+
+    x_counts = Counter(pos[0] for pos, _uv in records)
+    y_counts = Counter(pos[1] for pos, _uv in records)
+    z_counts = Counter(pos[2] for pos, _uv in records)
+    x_vals = [v for v, _n in x_counts.most_common(8)]
+    y_vals = [v for v, _n in y_counts.most_common(8)]
+    z_vals = [v for v, _n in z_counts.most_common(8)]
+
+    best_subset: list[tuple[tuple[float, float, float], tuple[int, int]]] | None = None
+    best_score = -1.0
+    best_bounds: tuple[float, float, float, float, float, float] | None = None
+    for x_pair in combinations(x_vals, 2):
+        for y_pair in combinations(y_vals, 2):
+            for z_pair in combinations(z_vals, 2):
+                min_x, max_x = sorted(x_pair)
+                min_y, max_y = sorted(y_pair)
+                min_z, max_z = sorted(z_pair)
+                size_x = abs(max_x - min_x)
+                size_y = abs(max_y - min_y)
+                size_z = abs(max_z - min_z)
+                if min(size_x, size_y, size_z) <= 0.0 or max(size_x, size_y, size_z) > 12.0:
+                    continue
+                subset = [
+                    rec
+                    for rec in records
+                    if rec[0][0] in x_pair and rec[0][1] in y_pair and rec[0][2] in z_pair
+                ]
+                uniq_pos = {pos for pos, _uv in subset}
+                if len(uniq_pos) < 8:
+                    continue
+                volume = size_x * size_y * size_z
+                score = len(subset) + len(uniq_pos) * 4 - volume * 0.35
+                if score > best_score:
+                    best_score = score
+                    best_subset = subset
+                    best_bounds = (min_x, max_x, min_y, max_y, min_z, max_z)
+
+    if best_subset is None or best_bounds is None:
+        return None
+
+    min_x, max_x, min_y, max_y, min_z, max_z = best_bounds
+    uv_faces: dict[str, dict[str, list[int]]] = {}
+    size_x = abs(max_x - min_x)
+    size_y = abs(max_y - min_y)
+    size_z = abs(max_z - min_z)
+    face_expect = {
+        "north": (size_x, size_y),
+        "south": (size_x, size_y),
+        "east": (size_z, size_y),
+        "west": (size_z, size_y),
+        "up": (size_x, size_z),
+        "down": (size_x, size_z),
+    }
+    for face in ("north", "east", "south", "west", "up", "down"):
+        face_records = _direct_cube_face_records(best_subset, best_bounds, face)
+        exp_w, exp_h = face_expect[face]
+        rect = _select_legacy_face_uv_rect(face_records, exp_w, exp_h)
+        if rect is None:
+            continue
+        uv0, size = rect
+        width, height = size
+        if face == "down":
+            uv_faces[face] = {"uv": [uv0[0], uv0[1] + height], "uv_size": [width, -height]}
+        else:
+            uv_faces[face] = {"uv": uv0, "uv_size": [width, height]}
+    if len(uv_faces) < 4:
+        return None
+
+    cube = {
+        "origin": [min_x, min_y, min_z],
+        "size": [round(size_x, 5), round(size_y, 5), round(size_z, 5)],
+        "uv": uv_faces,
+    }
+    return cube, {pos for pos, _uv in best_subset}
+
+
+def _build_legacy_direct_cubes(
+    payload: bytes,
+    tex_size: tuple[int, int] | None,
+    *,
+    preferred_count: int,
+) -> list[dict[str, object]]:
+    records = _extract_legacy_direct_cube_records(payload, tex_size)
+    if len(records) < 16:
+        return []
+    remaining = list(records)
+    cubes: list[dict[str, object]] = []
+    seen_keys: set[tuple[float, float, float, float, float, float]] = set()
+    target = max(4, min(max(1, preferred_count), 16))
+    while len(remaining) >= 8 and len(cubes) < target:
+        selected = _build_legacy_direct_cube_from_records(remaining)
+        if selected is None:
+            break
+        cube, used_positions = selected
+        key = tuple(round(v, 3) for v in (*cube["origin"], *cube["size"]))
+        if key in seen_keys:
+            break
+        seen_keys.add(key)
+        cubes.append(cube)
+        next_remaining = [rec for rec in remaining if rec[0] not in used_positions]
+        if len(next_remaining) == len(remaining):
+            break
+        remaining = next_remaining
+    return cubes
+
+
+def _filter_format15_entry_cubes(
+    entry: dict[str, object],
+    *,
+    pivot_override: object | None = None,
+) -> None:
+    cubes = entry.get("cubes")
+    if not isinstance(cubes, list) or not cubes:
+        return
+    entry["cubes"] = _filter_format15_cube_list(
+        cubes,
+        bone_name=str(entry.get("name", "")),
+        pivot=entry.get("pivot") if pivot_override is None else pivot_override,
+        enforce_pivot_distance=_format15_entry_enforces_pivot_distance(entry),
+    )
+    if not entry["cubes"]:
+        entry.pop("cubes", None)
+
+
+def _format15_entry_enforces_pivot_distance(entry: dict[str, object]) -> bool:
+    decode_mode = entry.get("__compiled_cube_decode_mode")
+    source = entry.get("__compiled_cube_source")
+    if decode_mode in {"child_allocated", "segmented_wrapper_records"}:
+        return False
+    if source in {
+        "typed:local_nested_visible",
+        "typed:container_slice_visible",
+        "fallback:same_visible_name",
+    }:
+        return False
+    return True
+
+
+def _best_format15_filter_context(
+    entry: dict[str, object],
+    by_name: dict[str, dict[str, object]],
+) -> list[dict[str, object]]:
+    cubes = entry.get("cubes")
+    if not isinstance(cubes, list) or not cubes:
+        return []
+    pivot_options: list[object] = [entry.get("pivot")]
+    parent_name = entry.get("parent")
+    if isinstance(parent_name, str):
+        parent_entry = by_name.get(parent_name)
+        if parent_entry is not None:
+            pivot_options.append(parent_entry.get("pivot"))
+    anchor_name = entry.get("__compiled_cube_anchor_name")
+    if isinstance(anchor_name, str):
+        anchor_entry = by_name.get(anchor_name)
+        if anchor_entry is not None:
+            pivot_options.append(anchor_entry.get("pivot"))
+    best = _filter_format15_cube_list(
+        cubes,
+        bone_name=str(entry.get("name", "")),
+        pivot=entry.get("pivot"),
+        enforce_pivot_distance=_format15_entry_enforces_pivot_distance(entry),
+    )
+    for pivot_option in pivot_options[1:]:
+        candidate = _filter_format15_cube_list(
+            cubes,
+            bone_name=str(entry.get("name", "")),
+            pivot=pivot_option,
+            enforce_pivot_distance=_format15_entry_enforces_pivot_distance(entry),
+        )
+        if len(candidate) > len(best):
+            best = candidate
+    return best
+
+
+def _filter_format15_cube_list(
+    cubes: list[dict[str, object]],
+    *,
+    bone_name: str,
+    pivot: object,
+    enforce_pivot_distance: bool = True,
+) -> list[dict[str, object]]:
+    pivot_xyz: tuple[float, float, float] | None = None
+    if isinstance(pivot, list) and len(pivot) == 3:
+        try:
+            pivot_xyz = (float(pivot[0]), float(pivot[1]), float(pivot[2]))
+        except Exception:
+            pivot_xyz = None
+
+    kept: list[dict[str, object]] = []
+    for cube in cubes:
+        size = cube.get("size")
+        if not isinstance(size, list) or len(size) != 3:
+            continue
+
+        sx, sy, sz = (float(size[0]), float(size[1]), float(size[2]))
+        if sx <= 0.0 or sy <= 0.0 or sz <= 0.0:
+            continue
+
+        max_dim = max(sx, sy, sz)
+        if max_dim > 20.0:
+            continue
+
+        if abs(sx * sy * sz) > 2000.0:
+            continue
+
+        if (
+            enforce_pivot_distance
+            and pivot_xyz is not None
+            and bone_name not in _FORMAT15_TORSO_CONTAINER_ANCHORS
+        ):
+            center = _legacy_cube_center(cube)
+            if center is not None:
+                dist = math.sqrt(
+                    (center[0] - pivot_xyz[0]) ** 2
+                    + (center[1] - pivot_xyz[1]) ** 2
+                    + (center[2] - pivot_xyz[2]) ** 2
+                )
+                if dist > max(18.0, max_dim * 1.75):
+                    continue
+
+        kept.append(cube)
+    return kept
+
+
+def _refine_legacy_bone_cubes(
+    bone_name: str,
+    bone_pivot: tuple[float, float, float] | None,
+    cubes: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    if not cubes or bone_pivot is None:
+        return cubes
+    if bone_name not in {"Head", "UpperBody"}:
+        return cubes
+
+    refined: list[dict[str, object]] = []
+    for cube in cubes:
+        center = _legacy_cube_center(cube)
+        size = cube.get("size", [0.0, 0.0, 0.0])
+        if center is None or not isinstance(size, list) or len(size) != 3:
+            refined.append(cube)
+            continue
+        dist = math.sqrt(
+            (center[0] - bone_pivot[0]) ** 2
+            + (center[1] - bone_pivot[1]) ** 2
+            + (center[2] - bone_pivot[2]) ** 2
+        )
+        max_dim = max(float(size[0]), float(size[1]), float(size[2]))
+        if dist > 15.0 and max_dim > 20.0:
+            continue
+        refined.append(cube)
+    if not refined:
+        refined = cubes[:1]
+    return refined
+
+
+def _build_legacy_direct_one_cube(
+    payload: bytes,
+    tex_size: tuple[int, int] | None,
+) -> dict[str, object] | None:
+    records = _extract_legacy_direct_cube_records(payload, tex_size)
+    selected = _build_legacy_direct_cube_from_records(records)
+    return None if selected is None else selected[0]
+
+
+def _extract_legacy_model_bones(
+    section: bytes,
+    names: tuple[str, ...],
+    *,
+    codec_format: int | None,
+) -> list[LegacyModelBoneInfo]:
+    hits = _iter_len_prefixed_names(section)
+    valid = set(names)
+    first_hit: dict[str, int] = {}
+    for off, name in hits:
+        if name in valid and name not in first_hit:
+            first_hit[name] = off
+
+    parent_map: dict[str, str] = {}
+    for off, parent in hits:
+        if parent not in valid:
+            continue
+        nxt = off + 1 + len(parent) + 1
+        if nxt >= len(section):
+            continue
+        child_len = section[nxt]
+        child_end = nxt + 1 + child_len
+        if not (1 <= child_len <= 32 and child_end < len(section) and section[child_end] == 0):
+            continue
+        try:
+            child = section[nxt + 1:child_end].decode("ascii")
+        except UnicodeDecodeError:
+            continue
+        if child in valid and child != parent and child not in parent_map:
+            parent_map[child] = parent
+
+    cube_count_guess: dict[str, int] = {}
+    for off, name in hits:
+        if not name.startswith("M"):
+            continue
+        visible = name[1:]
+        if visible not in valid:
+            continue
+        second = section.find(bytes([len(name)]) + name.encode("ascii"), off + 1)
+        if second < 0:
+            continue
+        data_off = second + 1 + len(name)
+        if data_off < len(section) and section[data_off] == 0:
+            data_off += 1
+        if data_off + 2 > len(section):
+            continue
+        count = section[data_off]
+        record_kind = section[data_off + 1]
+        if 0 <= count <= 0x40 and record_kind in (0x05, 0x06, 0x07):
+            cube_count_guess[visible] = count
+
+    out: list[LegacyModelBoneInfo] = []
+    for name in names:
+        off = first_hit.get(name)
+        pivot = _read_legacy_pivot(section, off, name) if off is not None else None
+        wrapper_name = None
+        uv_norm_hints: tuple[float, ...] = ()
+        wrapper = _find_legacy_wrapper_payload(section, name)
+        if wrapper is None and _LEGACY_WRAPPER_NAME_RE.fullmatch(name):
+            wrapper = _find_legacy_wrapper_payload_by_wrapper(section, name)
+        if wrapper is None:
+            wrapper = _find_legacy_visible_payload_same_name(section, name)
+        if wrapper is not None:
+            wrapper_name, count, _kind, payload = wrapper
+            if name not in cube_count_guess:
+                cube_count_guess[name] = count
+            uv_norm_hints = _extract_uv_norm_hints(payload)
+        out.append(
+            LegacyModelBoneInfo(
+                name=name,
+                parent=parent_map.get(name),
+                pivot=pivot,
+                cube_count_guess=cube_count_guess.get(name),
+                wrapper_name=wrapper_name,
+                uv_norm_hints=uv_norm_hints,
+            )
+        )
+    existing = {bone.name for bone in out}
+    if codec_format == 15:
+        wrapper_names = [name for _off, name in hits if _LEGACY_WRAPPER_NAME_RE.fullmatch(name)]
+        for wrapper_name in dict.fromkeys(wrapper_names):
+            if len(wrapper_name) >= 2 and wrapper_name[1].isdigit():
+                visible = wrapper_name
+            elif wrapper_name.startswith("MM"):
+                visible = wrapper_name
+            elif re.search(r"M[0-9]+$", wrapper_name):
+                visible = wrapper_name
+            else:
+                visible = wrapper_name[1:]
+            if not visible or visible in existing:
+                continue
+            wrapper = _find_legacy_wrapper_payload_by_wrapper(section, wrapper_name)
+            if wrapper is None:
+                continue
+            _wname, count, _kind, payload = wrapper
+            if count <= 0:
+                continue
+            if not _build_legacy_face_quad_cubes(payload, (256, 128)):
+                continue
+            if visible in {"M2", "M3", "M4", "M5", "MM1", "FM1", "FM2"} or re.search(r"(Left|Right)M[0-9]+$", visible):
+                parent = "Head"
+            else:
+                parent = "Head" if any(tok in visible for tok in ("Left", "Right", "H", "F", "G", "J")) else "AllBody"
+            out.append(
+                LegacyModelBoneInfo(
+                    name=visible,
+                    parent=parent,
+                    pivot=None,
+                    cube_count_guess=count,
+                    wrapper_name=wrapper_name,
+                    uv_norm_hints=_extract_uv_norm_hints(payload),
+                )
+            )
+    return out
+
+
+def _repair_legacy_bone_parents(
+    bones: list[LegacyModelBoneInfo],
+    *,
+    codec_format: int | None,
+) -> list[LegacyModelBoneInfo]:
+    by_name = {bone.name: bone for bone in bones}
+    repaired: list[LegacyModelBoneInfo] = []
+    for bone in bones:
+        parent = bone.parent
+        if parent is None:
+            if bone.name == "UpperBody" and "AllBody" in by_name:
+                parent = "AllBody"
+            elif bone.name == "Head" and "UpperBody" in by_name:
+                parent = "UpperBody"
+            elif bone.name == "Arm" and "UpperBody" in by_name:
+                parent = "UpperBody"
+            elif bone.name == "LongHair" and "MLongHair" in by_name:
+                parent = "MLongHair"
+            elif bone.name == "LongHair2" and "LongHair" in by_name:
+                parent = "LongHair"
+            elif bone.name == "LongLeftHair" and "MLongLeftHair" in by_name:
+                parent = "MLongLeftHair"
+            elif bone.name == "LongLeftHair2" and "LongLeftHair" in by_name:
+                parent = "LongLeftHair"
+            elif bone.name == "LongRightHair" and "MLongRightHair" in by_name:
+                parent = "MLongRightHair"
+            elif bone.name == "LongRightHair2" and "LongRightHair" in by_name:
+                parent = "LongRightHair"
+            elif bone.name == "BaseHair" and "Hair" in by_name:
+                parent = "Hair"
+            elif bone.name == "bone5" and "BaseHair" in by_name:
+                parent = "BaseHair"
+            elif bone.name in {"Left_ear", "Right_ear"} and "Ear" in by_name:
+                parent = "Ear"
+            elif bone.name == "Mask" and "Head" in by_name:
+                parent = "Head"
+            elif bone.name in {"kongju", "jingya", "xiao", "weixiao"} and "Mouth" in by_name:
+                parent = "Mouth"
+            elif bone.name in {"LeftArm", "RightArm"} and "Arm" in by_name:
+                parent = "Arm"
+            elif bone.name == "LeftForeArm" and "LeftArm" in by_name:
+                parent = "LeftArm"
+            elif bone.name == "RightForeArm" and "RightArm" in by_name:
+                parent = "RightArm"
+            elif bone.name == "LeftHand" and "LeftForeArm" in by_name:
+                parent = "LeftForeArm"
+            elif bone.name == "RightHand" and "RightForeArm" in by_name:
+                parent = "RightForeArm"
+            elif bone.name == "FM" and "FrontClothe" in by_name:
+                parent = "FrontClothe"
+            elif bone.name == "FM1" and "FM" in by_name:
+                parent = "FM"
+            elif bone.name == "FM2" and "FM1" in by_name:
+                parent = "FM1"
+            elif bone.name == "RightEyelidBase" and "RightEyelid" in by_name:
+                parent = "RightEyelid"
+            elif bone.name == "RightEyeDot" and "RightEyelidBase" in by_name:
+                parent = "RightEyelidBase"
+            elif codec_format == 15:
+                m = re.fullmatch(r"([HFGJ](?:Left|Right)M)(\d+)", bone.name)
+                if m is not None:
+                    prefix, idx_text = m.groups()
+                    idx = int(idx_text)
+                    anchor = f"{prefix}1"
+                    if idx >= 2 and anchor in by_name:
+                        parent = anchor
+                    elif "Head" in by_name:
+                        parent = "Head"
+                elif bone.name == "FM2" and "FM1" in by_name:
+                    parent = "FM1"
+                elif bone.name in {"FM1", "MM1"} and "Head" in by_name:
+                    parent = "Head"
+                elif re.fullmatch(r"M[2-9]\d*", bone.name) and "Head" in by_name:
+                    parent = "Head"
+        if parent == bone.parent:
+            repaired.append(bone)
+        else:
+            repaired.append(
+                LegacyModelBoneInfo(
+                    name=bone.name,
+                    parent=parent,
+                    pivot=bone.pivot,
+                    cube_count_guess=bone.cube_count_guess,
+                    wrapper_name=bone.wrapper_name,
+                    uv_norm_hints=bone.uv_norm_hints,
+                )
+            )
+    return repaired
+
+
+def _prune_format15_main_model_bones(bones: list[LegacyModelBoneInfo]) -> list[LegacyModelBoneInfo]:
+    by_name = {bone.name: bone for bone in bones}
+    family_counts = Counter(_legacy_name_family_key(name) for name in by_name)
+    arrow_names = {
+        "UpPl", "DownPl", "LeftPl", "RightPl", "Other",
+        "Bowknot", "Bowknot2", "Bowknot3", "Bowknot4", "Bowknot5",
+        "Board", "Board2", "Brand", "Sakura",
+    }
+    noise_names = {"M", "geometry.unknown", "LeftWaistLocator2", "SheathLocator2", "attacked", "boat", "climb", "climbing", "elytra_fly", "fly"}
+    core_tokens = ("Root", "Body", "Head", "Hair", "Arm", "Leg", "Hand", "Foot", "Eye", "Brow", "Ear", "Tail", "Wing", "Ribbon", "Skirt", "Sleeve", "Clothe", "Mask", "Waist", "Locator", "bow", "gui", "FOX", "Mouth")
+    family_re = re.compile(r"(?:[A-Z]{2,3}\d{0,2}|FFM\d(?:_\d)?|[LR][BFM]\d{0,2}|[FB][LRM]\d{0,2}|LM\d{0,2}|RM\d{0,2}|FM\d{0,2})$")
+    kept: list[LegacyModelBoneInfo] = []
+    for bone in bones:
+        name = bone.name
+        if name in noise_names or name in arrow_names:
+            continue
+        if name.startswith(("ysm.", "query.", "math.")):
+            continue
+        keep = False
+        if bone.wrapper_name is not None or bone.cube_count_guess is not None or bone.parent is not None:
+            keep = True
+        if bone.pivot is not None and (
+            any(tok in name for tok in core_tokens)
+            or "_" in name
+            or any(ch.islower() for ch in name)
+            or family_counts[_legacy_name_family_key(name)] >= 2
+            or family_re.fullmatch(name) is not None
+        ):
+            keep = True
+        if name.startswith("M") and len(name) > 1 and name[1:] in by_name:
+            keep = True
+        if keep:
+            kept.append(bone)
+    return kept or bones
+
+
+def _prune_legacy_model_bones(
+    bones: list[LegacyModelBoneInfo],
+    *,
+    codec_format: int | None,
+    asset_name: str | None,
+) -> list[LegacyModelBoneInfo]:
+    if codec_format == 9 and asset_name in {"main_model", "arrow_model"}:
+        return bones
+    if len(bones) <= 96:
+        return bones
+    by_name = {bone.name: bone for bone in bones}
+    keep: set[str] = set()
+    for bone in bones:
+        if bone.wrapper_name is not None or bone.cube_count_guess is not None:
+            keep.add(bone.name)
+        if bone.parent is not None:
+            keep.add(bone.name)
+            keep.add(bone.parent)
+        if bone.pivot is not None and any(tok in bone.name for tok in _LEGACY_BONE_NAME_HINTS):
+            keep.add(bone.name)
+    changed = True
+    while changed:
+        changed = False
+        for name in tuple(keep):
+            bone = by_name.get(name)
+            if bone and bone.parent and bone.parent not in keep:
+                keep.add(bone.parent)
+                changed = True
+    pruned = [bone for bone in bones if bone.name in keep]
+    return pruned or bones
+
+
+def _legacy_model_identifier(section: bytes) -> str:
+    m = re.search(rb"geometry\.[A-Za-z0-9_.-]+", section)
+    if m is None:
+        return "geometry.unknown"
+    return m.group().decode("ascii", "replace")
+
+
+def _legacy_model_texture_size(asset_name: str | None) -> tuple[int, int] | None:
+    if asset_name in ("main_model", "arm_model"):
+        return (256, 256)
+    if asset_name == "arrow_model":
+        return (64, 64)
+    return None
+
+
+def _format9_model_names(section: bytes, asset_name: str | None) -> tuple[str, ...]:
+    names = tuple(dict.fromkeys(name for _off, name in _iter_len_prefixed_names(section)))
+    if not names:
+        names = tuple(dict.fromkeys(_extract_names(section, limit=256)))
+        if not names:
+            return tuple()
+    if asset_name == "main_model":
+        return tuple(name for name in names if name not in _FORMAT9_MAIN_MODEL_EXCLUDE_NAMES)
+    if asset_name == "arm_model":
+        broad = tuple(dict.fromkeys(_extract_names(section, limit=256)))
+        return tuple(name for name in broad if name in _FORMAT9_ARM_MODEL_KEEP_NAMES)
+    if asset_name == "arrow_model":
+        broad = tuple(dict.fromkeys(_extract_names(section, limit=256)))
+        keep_hits = sum(name in _FORMAT9_ARROW_MODEL_KEEP_NAMES for name in broad)
+        if keep_hits >= 3:
+            return tuple(name for name in broad if name in _FORMAT9_ARROW_MODEL_KEEP_NAMES)
+        filtered: list[str] = []
+        seen: set[str] = set()
+        for name in broad:
+            if name in _FORMAT9_ARROW_MODEL_EXCLUDE_NAMES:
+                continue
+            if name.startswith(("math.", "query.", "ysm.", "v.")):
+                continue
+            if "." in name or "-" in name:
+                continue
+            if re.fullmatch(r"[A-Z0-9]{2,5}", name):
+                continue
+            if name not in seen:
+                seen.add(name)
+                filtered.append(name)
+        return tuple(filtered)
+    return names
+
+
+def _format9_arrow_signature_score(section: bytes) -> int:
+    return sum(name.encode("ascii") in section for name in _FORMAT9_ARROW_MODEL_KEEP_NAMES)
+
+
+def _select_format9_arrow_section(scan: LegacyScanResult, decoded: bytes) -> LegacySection | None:
+    best: LegacySection | None = None
+    best_key: tuple[int, int, int] | None = None
+    for idx, sec in enumerate(scan.sections):
+        section_bytes = decoded[sec.start:sec.end]
+        score = _format9_arrow_signature_score(section_bytes)
+        if score <= 0:
+            continue
+        prefer = 1 if sec.asset_guess != "main_model" else 0
+        key = (prefer, score, -sec.size)
+        if best_key is None or key > best_key:
+            best = sec
+            best_key = key
+    if best_key is None:
+        return None
+    if best_key[1] < 3:
+        return None
+    return best
+
+
+def _legacy_model_name_hit_score(
+    section: bytes,
+    *,
+    asset_name: str | None,
+    codec_format: int | None,
+) -> int:
+    if asset_name == "arm_model":
+        names = tuple(sorted(_FORMAT9_ARM_MODEL_KEEP_NAMES))
+    elif asset_name == "arrow_model":
+        names = tuple(sorted(_FORMAT9_ARROW_MODEL_KEEP_NAMES))
+    else:
+        return 0
+    discovered_names = set(_format15_model_names(section) if codec_format == 15 else _format9_model_names(section, asset_name))
+    return sum(160 for name in names if name in discovered_names)
+
+
+def _legacy_model_payload_hit_score(
+    section: bytes,
+    *,
+    asset_name: str | None,
+    codec_format: int | None,
+) -> int:
+    del codec_format
+    if asset_name == "arm_model":
+        names = tuple(sorted(_FORMAT9_ARM_MODEL_KEEP_NAMES))
+    elif asset_name == "arrow_model":
+        names = tuple(sorted(_FORMAT9_ARROW_MODEL_KEEP_NAMES))
+    else:
+        return 0
+    score = 0
+    for name in names:
+        candidate = (
+            _find_legacy_wrapper_payload(section, name)
+            or _find_legacy_visible_payload_same_name(section, name)
+        )
+        if candidate is None:
+            continue
+        score += 100 + min(int(candidate[1]), 32)
+    return score
+
+
+def _select_legacy_model_source_section(
+    scan: LegacyScanResult,
+    decoded: bytes,
+    *,
+    current_index: int,
+    asset_name: str | None,
+    codec_format: int | None,
+) -> tuple[int, LegacySection]:
+    current = scan.sections[current_index]
+    if codec_format not in (9, 15) or asset_name not in {"arm_model", "arrow_model"}:
+        return current_index, current
+
+    current_payload_score = _legacy_model_payload_hit_score(
+        decoded[current.start : current.end],
+        asset_name=asset_name,
+        codec_format=codec_format,
+    )
+    current_name_score = _legacy_model_name_hit_score(
+        decoded[current.start : current.end],
+        asset_name=asset_name,
+        codec_format=codec_format,
+    )
+    current_exact = 1 if current.asset_guess == asset_name else 0
+    best_index = current_index
+    best_section = current
+    prefer_exact_first = bool(current_exact and current_payload_score > 0)
+    if prefer_exact_first:
+        best_key = (current_exact, current_payload_score, current_name_score, current.size)
+    else:
+        best_key = (current_payload_score, current_name_score, current_exact, current.size)
+    for idx, sec in enumerate(scan.sections):
+        if sec.kind_guess != "model":
+            continue
+        section_bytes = decoded[sec.start : sec.end]
+        payload_score = _legacy_model_payload_hit_score(
+            section_bytes,
+            asset_name=asset_name,
+            codec_format=codec_format,
+        )
+        name_score = _legacy_model_name_hit_score(
+            section_bytes,
+            asset_name=asset_name,
+            codec_format=codec_format,
+        )
+        exact = 1 if sec.asset_guess == asset_name else 0
+        key = (
+            (exact, payload_score, name_score, sec.size)
+            if prefer_exact_first
+            else (payload_score, name_score, exact, sec.size)
+        )
+        if key > best_key:
+            best_index = idx
+            best_section = sec
+            best_key = key
+
+    if best_key[0] <= 0 and codec_format == 9 and asset_name == "arrow_model":
+        fallback = _select_format9_arrow_section(scan, decoded)
+        if fallback is not None:
+            fallback_index = next(
+                (idx for idx, sec in enumerate(scan.sections) if sec == fallback),
+                current_index,
+            )
+            return fallback_index, fallback
+    return best_index, best_section
+
+
+def _pivot_lists_close(a: object, b: object, *, tol: float = 1e-4) -> bool:
+    if not (isinstance(a, list) and isinstance(b, list) and len(a) == 3 and len(b) == 3):
+        return False
+    try:
+        return all(abs(float(x) - float(y)) <= tol for x, y in zip(a, b))
+    except Exception:
+        return False
+
+
+def _cubes_equal(a: object, b: object) -> bool:
+    if not (isinstance(a, list) and isinstance(b, list)):
+        return False
+    try:
+        return json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+    except Exception:
+        return False
+
+
+def _collapse_redundant_wrapper_bones(
+    bone_entries: list[dict[str, object]],
+    *,
+    preserve_names: set[str] | None = None,
+) -> list[dict[str, object]]:
+    by_name = {str(entry.get("name")): entry for entry in bone_entries if isinstance(entry.get("name"), str)}
+    referenced_parents = {
+        str(entry.get("parent"))
+        for entry in bone_entries
+        if isinstance(entry.get("parent"), str)
+    }
+    drop: set[str] = set()
+    preserve = preserve_names or set()
+    for entry in bone_entries:
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.startswith("M") or len(name) < 2:
+            continue
+        if name in preserve or name in referenced_parents:
+            continue
+        visible = name[1:]
+        other = by_name.get(visible)
+        if other is None:
+            continue
+        cubes_a = entry.get("cubes")
+        cubes_b = other.get("cubes")
+        pivot_a = entry.get("pivot")
+        pivot_b = other.get("pivot")
+        redundant = False
+        if cubes_a in (None, []):
+            redundant = True
+        elif cubes_b not in (None, []) and _pivot_lists_close(pivot_a, pivot_b) and _cubes_equal(cubes_a, cubes_b):
+            redundant = True
+        if not redundant:
+            continue
+        parent = entry.get("parent")
+        if isinstance(parent, str):
+            if other.get("parent") in (None, name):
+                other["parent"] = parent
+        drop.add(name)
+
+    if not drop:
+        return bone_entries
+
+    collapsed: list[dict[str, object]] = []
+    for entry in bone_entries:
+        name = entry.get("name")
+        if isinstance(name, str) and name in drop:
+            continue
+        parent = entry.get("parent")
+        visited: set[str] = set()
+        while isinstance(parent, str) and parent in drop and parent not in visited:
+            visited.add(parent)
+            parent = by_name.get(parent, {}).get("parent")
+        if isinstance(parent, str):
+            entry["parent"] = parent
+        else:
+            entry.pop("parent", None)
+        collapsed.append(entry)
+    return collapsed
+
+
+def _apply_legacy_precision_guards(
+    bone_entries: list[dict[str, object]],
+    *,
+    asset_name: str | None,
+) -> tuple[list[dict[str, object]], dict[str, int]]:
+    if asset_name != "main_model":
+        return bone_entries, {
+            "fanout_group_rejections": 0,
+            "container_parent_rejections": 0,
+        }
+
+    by_name = {
+        str(entry.get("name")): entry
+        for entry in bone_entries
+        if isinstance(entry.get("name"), str)
+    }
+    children_by_parent: dict[str, list[str]] = {}
+    for entry in bone_entries:
+        name = entry.get("name")
+        parent = entry.get("parent")
+        if isinstance(name, str) and isinstance(parent, str):
+            children_by_parent.setdefault(parent, []).append(name)
+
+    fanout_group_rejections = 0
+    named_follow_groups: dict[tuple[str, str], list[dict[str, object]]] = {}
+    for entry in bone_entries:
+        if not entry.get("cubes"):
+            continue
+        name = entry.get("name")
+        decode_mode = entry.get("__compiled_cube_decode_mode")
+        if (
+            isinstance(name, str)
+            and name in _LEGACY_SEGMENTED_WRAPPER_ALLOW_BONES
+            and decode_mode == "segmented_wrapper_records"
+        ):
+            continue
+        source = entry.get("__compiled_cube_source")
+        anchor = entry.get("__compiled_cube_anchor_name")
+        payload = entry.get("__compiled_cube_payload_name")
+        if source != "typed:local_named_follow":
+            continue
+        if not (isinstance(anchor, str) and isinstance(payload, str)):
+            continue
+        if anchor != payload:
+            continue
+        named_follow_groups.setdefault((anchor, payload), []).append(entry)
+
+    for (_anchor, _payload), group in named_follow_groups.items():
+        if len(group) <= 1:
+            continue
+        for entry in group:
+            if entry.pop("cubes", None) is not None:
+                entry["__compiled_cube_rejected_reason"] = "fanout_local_named_follow"
+                fanout_group_rejections += 1
+
+    container_parent_rejections = 0
+    container_sources = {
+        "typed:local_named_follow",
+        "fallback:wrapper_name",
+        "fallback:same_visible_name",
+        "fallback:parent_linked",
+    }
+    for entry in bone_entries:
+        if not entry.get("cubes"):
+            continue
+        name = entry.get("name")
+        source = entry.get("__compiled_cube_source")
+        anchor = entry.get("__compiled_cube_anchor_name")
+        payload = entry.get("__compiled_cube_payload_name")
+        parent = entry.get("parent")
+        wrapper = entry.get("__compiled_wrapper_name")
+        decode_mode = entry.get("__compiled_cube_decode_mode")
+        if not (isinstance(name, str) and isinstance(source, str)):
+            continue
+        if (
+            name in _LEGACY_SEGMENTED_WRAPPER_ALLOW_BONES
+            and decode_mode == "segmented_wrapper_records"
+        ):
+            continue
+        children = children_by_parent.get(name, ())
+        if len(children) < 2:
+            continue
+        is_container_source = source in container_sources
+        if (
+            not is_container_source
+            and source == "typed:local_nested_visible"
+            and isinstance(anchor, str)
+            and isinstance(payload, str)
+            and isinstance(parent, str)
+            and anchor == parent
+        ):
+            relation_names = {name, parent}
+            if isinstance(wrapper, str):
+                relation_names.add(wrapper)
+            if payload not in relation_names:
+                is_container_source = True
+        if not is_container_source:
+            continue
+        child_support = 0
+        for child_name in children:
+            child = by_name.get(child_name)
+            if child is None:
+                continue
+            if (
+                child.get("__compiled_cube_count_guess") is not None
+                or child.get("__compiled_wrapper_name") is not None
+                or child.get("cubes")
+            ):
+                child_support += 1
+        if child_support < 2:
+            continue
+        if entry.pop("cubes", None) is not None:
+            entry["__compiled_cube_rejected_reason"] = "multi_child_container_source"
+            container_parent_rejections += 1
+
+    return bone_entries, {
+        "fanout_group_rejections": fanout_group_rejections,
+        "container_parent_rejections": container_parent_rejections,
+    }
+
+
+def _build_legacy_model_canonical_json(
+    asset_name: str | None,
+    section: bytes,
+    names: tuple[str, ...],
+    *,
+    codec_format: int | None,
+    geometry_section: bytes | None = None,
+) -> dict[str, object]:
+    decode_section = section if geometry_section is None else geometry_section
+    # The section manifest keeps only a short preview of names; the full model
+    # parser should re-scan the whole section so wrappers like MHead are not lost.
+    if codec_format == 9:
+        format9_names = _format9_model_names(section, asset_name)
+        if format9_names:
+            names = format9_names
+        else:
+            rich_names = tuple(dict.fromkeys(_extract_names(section, limit=256)))
+            if rich_names:
+                names = rich_names
+    elif codec_format == 15:
+        format15_names = _format15_model_names(section)
+        if format15_names:
+            names = format15_names
+    else:
+        rich_names = tuple(dict.fromkeys(_extract_names(section, limit=256)))
+        if rich_names:
+            names = rich_names
+    bones = _extract_legacy_model_bones(section, names, codec_format=codec_format)
+    bones = _repair_legacy_bone_parents(bones, codec_format=codec_format)
+    if codec_format == 15 and asset_name == "main_model":
+        bones = _prune_format15_main_model_bones(bones)
+    else:
+        bones = _prune_legacy_model_bones(bones, codec_format=codec_format, asset_name=asset_name)
+    tex = _legacy_model_texture_size(asset_name)
+    bone_entries: list[dict[str, object]] = []
+    for bone in bones:
+        entry: dict[str, object] = {"name": bone.name}
+        if bone.parent:
+            entry["parent"] = bone.parent
+        if bone.pivot is not None:
+            entry["pivot"] = list(bone.pivot)
+        if bone.cube_count_guess is not None:
+            entry["__compiled_cube_count_guess"] = bone.cube_count_guess
+        if bone.wrapper_name is not None:
+            entry["__compiled_wrapper_name"] = bone.wrapper_name
+        if bone.uv_norm_hints:
+            entry["__compiled_uv_norm_hints"] = list(bone.uv_norm_hints)
+        candidate_rank = _rank_legacy_model_bone_payloads(
+            decode_section,
+            bone_name=bone.name,
+            parent_name=bone.parent,
+            wrapper_name=bone.wrapper_name,
+        )
+        best_candidate_meta: tuple[str, str, str, int, str] | None = None
+        best_candidate_cubes: list[dict[str, object]] = []
+        best_candidate_key: tuple[int, int, int, int, int, int, int] | None = None
+        for candidate in candidate_rank:
+            cubes, candidate_meta = _decode_legacy_model_candidate_cubes(
+                decode_section,
+                candidate,
+                bone_name=bone.name,
+                bone_pivot=bone.pivot,
+                wrapper_name=bone.wrapper_name,
+                preferred_count=max(1, bone.cube_count_guess or 1),
+                codec_format=codec_format,
+                tex=tex,
+            )
+            if codec_format == 15 and asset_name == "main_model" and cubes:
+                cubes = _filter_format15_cube_list(
+                    cubes,
+                    bone_name=bone.name,
+                    pivot=list(bone.pivot) if bone.pivot is not None else None,
+                )
+            key = (
+                1 if cubes else 0,
+                len(cubes),
+                *_legacy_typed_payload_candidate_score(
+                    candidate,
+                    bone_name=bone.name,
+                    parent_name=bone.parent,
+                    wrapper_name=bone.wrapper_name,
+                ),
+            )
+            if best_candidate_key is None or key > best_candidate_key:
+                best_candidate_key = key
+                best_candidate_cubes = cubes
+                best_candidate_meta = candidate_meta
+        if best_candidate_meta is not None:
+            entry["__compiled_cube_source"] = best_candidate_meta[0]
+            entry["__compiled_cube_anchor_name"] = best_candidate_meta[1]
+            entry["__compiled_cube_payload_name"] = best_candidate_meta[2]
+            entry["__compiled_cube_payload_kind"] = best_candidate_meta[3]
+            entry["__compiled_cube_decode_mode"] = best_candidate_meta[4]
+            if best_candidate_cubes:
+                entry["cubes"] = best_candidate_cubes
+        if "cubes" not in entry and bone.cube_count_guess is not None:
+            container_slice = _find_legacy_single_visible_container_slice(decode_section, bone.name)
+            if container_slice is not None:
+                nested_visible = _unwrap_legacy_nested_visible_payload(container_slice)
+                if nested_visible is None:
+                    nested_visible = _unwrap_legacy_inline_visible_payload(container_slice)
+                if nested_visible is not None and nested_visible[0] == bone.name:
+                    cubes = _decode_legacy_payload_cubes(
+                        nested_visible[3],
+                        tex,
+                        bone_name=bone.name,
+                        bone_pivot=bone.pivot,
+                        preferred_count=max(1, bone.cube_count_guess),
+                    )
+                    if codec_format == 15 and asset_name == "main_model" and cubes:
+                        cubes = _filter_format15_cube_list(
+                            cubes,
+                            bone_name=bone.name,
+                            pivot=list(bone.pivot) if bone.pivot is not None else None,
+                        )
+                    if cubes:
+                        entry["cubes"] = cubes
+                        entry["__compiled_cube_source"] = "typed:container_slice_visible"
+                        entry["__compiled_cube_anchor_name"] = bone.name
+                        entry["__compiled_cube_payload_name"] = nested_visible[0]
+                        entry["__compiled_cube_payload_kind"] = nested_visible[2]
+                        entry["__compiled_cube_decode_mode"] = "flat_payload"
+        bone_entries.append(entry)
+
+    if codec_format == 15 and asset_name == "main_model":
+        filtered_entries = bone_entries
+    else:
+        filtered_entries = _collapse_redundant_wrapper_bones(bone_entries)
+    if codec_format == 9:
+        filtered_entries = _postprocess_format9_model_entries(filtered_entries, asset_name=asset_name)
+    filtered_entries, child_allocation_summary = _apply_legacy_main_model_child_allocation(
+        filtered_entries,
+        section=decode_section,
+        tex=tex,
+        codec_format=codec_format,
+        asset_name=asset_name,
+    )
+    filtered_entries, aux_child_allocation_summary = _apply_legacy_aux_model_child_allocation(
+        filtered_entries,
+        section=decode_section,
+        tex=tex,
+        codec_format=codec_format,
+        asset_name=asset_name,
+    )
+    child_allocation_summary = _merge_child_allocation_summaries(
+        child_allocation_summary,
+        aux_child_allocation_summary,
+    )
+    filtered_entries, precision_summary = _apply_legacy_precision_guards(
+        filtered_entries,
+        asset_name=asset_name,
+    )
+    if codec_format == 15:
+        filtered_entries = _postprocess_format15_model_entries(filtered_entries, asset_name=asset_name)
+
+    description: dict[str, object] = {
+        "identifier": _legacy_model_identifier(section),
+    }
+    if tex is not None:
+        description["texture_width"] = tex[0]
+        description["texture_height"] = tex[1]
+    return {
+        "format_version": "1.12.0",
+        "__compiled_semantics": {
+            "typed_bone_hits": sum(
+                1
+                for entry in filtered_entries
+                if isinstance(entry.get("__compiled_cube_source"), str)
+                and str(entry["__compiled_cube_source"]).startswith("typed:")
+                and entry.get("cubes")
+            ),
+            "fallback_bone_hits": sum(
+                1
+                for entry in filtered_entries
+                if isinstance(entry.get("__compiled_cube_source"), str)
+                and str(entry["__compiled_cube_source"]).startswith("fallback:")
+                and entry.get("cubes")
+            ),
+            "segmented_record_bone_hits": sum(
+                1
+                for entry in filtered_entries
+                if entry.get("__compiled_cube_decode_mode") == "segmented_wrapper_records"
+                and entry.get("cubes")
+            ),
+            "child_allocated_bone_hits": int(child_allocation_summary["child_allocated_bone_hits"]),
+            "repaired_parent_bones": int(child_allocation_summary["repaired_parent_bones"]),
+            "head_child_allocations": int(child_allocation_summary["head_child_allocations"]),
+            "mask_child_allocated_bone_hits": int(child_allocation_summary["mask_child_allocated_bone_hits"]),
+            "head_structural_repairs": int(child_allocation_summary["head_structural_repairs"]),
+            "ear_child_allocations": int(child_allocation_summary["ear_child_allocations"]),
+            "foot_child_allocations": int(child_allocation_summary["foot_child_allocations"]),
+            "leg_child_allocations": int(child_allocation_summary["leg_child_allocations"]),
+            "tail_child_allocations": int(child_allocation_summary["tail_child_allocations"]),
+            "body_child_allocations": int(child_allocation_summary["body_child_allocations"]),
+            "hair_child_allocations": int(child_allocation_summary["hair_child_allocations"]),
+            "mouth_child_allocations": int(child_allocation_summary["mouth_child_allocations"]),
+            "arm_child_allocations": int(child_allocation_summary["arm_child_allocations"]),
+            "fanout_group_rejections": int(precision_summary["fanout_group_rejections"]),
+            "container_parent_rejections": int(precision_summary["container_parent_rejections"]),
+        },
+        "minecraft:geometry": [
+            {
+                "description": description,
+                "bones": filtered_entries,
+            }
+        ],
+    }
+
+
+def _format9_pair_name(name: str) -> str | None:
+    if name.startswith("Left"):
+        return "Right" + name[4:]
+    if name.startswith("Right"):
+        return "Left" + name[5:]
+    if name.startswith("Left_"):
+        return "Right_" + name[5:]
+    if name.startswith("Right_"):
+        return "Left_" + name[6:]
+    return None
+
+
+def _postprocess_format15_model_entries(
+    entries: list[dict[str, object]],
+    *,
+    asset_name: str | None,
+) -> list[dict[str, object]]:
+    arm_order = (
+        "Arm",
+        "LeftArm",
+        "LeftForeArm",
+        "LeftHand",
+        "LeftHandLocator",
+        "RightArm",
+        "RightForeArm",
+        "RightHand",
+        "RightHandLocator",
+    )
+    arrow_order = (
+        "Root",
+        "UpPl",
+        "DownPl",
+        "LeftPl",
+        "RightPl",
+        "Other",
+        "Bowknot",
+        "Bowknot2",
+        "Bowknot3",
+        "Bowknot4",
+        "Bowknot5",
+        "Board",
+        "Board2",
+        "Brand",
+        "Sakura",
+    )
+    if asset_name == "main_model":
+        by_name = {
+            entry["name"]: entry
+            for entry in entries
+            if isinstance(entry.get("name"), str)
+        }
+        wrapper_restore_names = {
+            "Bangs",
+            "LeftSideHair",
+            "RightSideHair",
+            "LongHair",
+            "LongLeftHair",
+            "LongRightHair",
+            "Head",
+            "UpBody",
+            "UpperBody",
+            "Tail",
+        }
+        explicit_parent_rules = {
+            "AllHead": "UpperBody",
+            "bow": "UpperBody",
+            "LeftEyelid": "Eyelid",
+            "RightEyelid": "Eyelid",
+            "LeftEyebrow": "EyeBrow",
+            "RightEyebrow": "EyeBrow",
+            "LeftEyePublic": "LeftEyelidBase",
+            "RightEyePublic": "RightEyelidBase",
+            "LeftEyeDot": "LeftEyelidBase",
+            "RightEyeDot": "RightEyelidBase",
+            "Left_ear": "Ear",
+            "Right_ear": "Ear",
+            "LeftArm": "Arm",
+            "RightArm": "Arm",
+        }
+        for entry in entries:
+            name = entry.get("name")
+            if not isinstance(name, str) or name.startswith("M"):
+                continue
+            wrapper_parent = f"M{name}"
+            wrapper_entry = by_name.get(wrapper_parent)
+            parent = entry.get("parent")
+            wrapper_parent_parent = (
+                wrapper_entry.get("parent")
+                if isinstance(wrapper_entry, dict)
+                and isinstance(wrapper_entry.get("parent"), str)
+                else None
+            )
+            wrapped_parent = (
+                f"M{wrapper_parent_parent}"
+                if isinstance(wrapper_parent_parent, str) and f"M{wrapper_parent_parent}" in by_name
+                else None
+            )
+            if (
+                wrapper_entry is not None
+                and (
+                    parent is None
+                    or parent == wrapper_parent_parent
+                    or parent == wrapped_parent
+                    or (
+                        name in wrapper_restore_names
+                        and parent in {"AllBody", "AllHead", "Hair"}
+                    )
+                )
+            ):
+                entry["parent"] = wrapper_parent
+                continue
+            if parent is None:
+                explicit_parent = explicit_parent_rules.get(name)
+                if explicit_parent is not None and explicit_parent in by_name:
+                    entry["parent"] = explicit_parent
+        referenced_parents = {
+            str(entry.get("parent"))
+            for entry in entries
+            if isinstance(entry.get("parent"), str)
+        }
+        entries = _collapse_redundant_wrapper_bones(entries, preserve_names=referenced_parents)
+        def _filter_main_entry(entry: dict[str, object]) -> None:
+            cubes = entry.get("cubes")
+            if not isinstance(cubes, list) or not cubes:
+                return
+            if entry.get("__compiled_cube_decode_mode") != "child_allocated":
+                _filter_format15_entry_cubes(entry)
+                return
+            best = _best_format15_filter_context(entry, by_name)
+            if best:
+                entry["cubes"] = best
+            else:
+                entry.pop("cubes", None)
+        for entry in entries:
+            _filter_main_entry(entry)
+        entries = _filter_format15_main_model_entries(entries)
+        by_name = {
+            entry["name"]: entry
+            for entry in entries
+            if isinstance(entry.get("name"), str)
+        }
+        referenced_parents = {
+            str(entry.get("parent"))
+            for entry in entries
+            if isinstance(entry.get("parent"), str)
+        }
+        filtered: list[dict[str, object]] = []
+        for entry in entries:
+            name = entry.get("name")
+            if not isinstance(name, str):
+                continue
+            if name.startswith("M") and not entry.get("cubes") and name not in referenced_parents:
+                continue
+            filtered.append(entry)
+        by_name = {
+            entry["name"]: entry
+            for entry in filtered
+            if isinstance(entry.get("name"), str)
+        }
+        swapped: set[str] = set()
+        for name, entry in by_name.items():
+            if name in swapped:
+                continue
+            other_name = _format9_pair_name(name)
+            if other_name is None or other_name not in by_name:
+                continue
+            other = by_name[other_name]
+            x0 = _format9_entry_pivot_x(entry)
+            x1 = _format9_entry_pivot_x(other)
+            if x0 is None or x1 is None:
+                continue
+            should_swap = False
+            if name.startswith("Left") and x0 < 0.0 and x1 > 0.0:
+                should_swap = True
+            elif name.startswith("Right") and x0 > 0.0 and x1 < 0.0:
+                should_swap = True
+            elif name.startswith("Left_") and x0 < 0.0 and x1 > 0.0:
+                should_swap = True
+            elif name.startswith("Right_") and x0 > 0.0 and x1 < 0.0:
+                should_swap = True
+            if should_swap:
+                _swap_format9_entry_payload(entry, other)
+                swapped.add(name)
+                swapped.add(other_name)
+        for entry in filtered:
+            name = entry.get("name")
+            if not isinstance(name, str):
+                continue
+            cubes = entry.get("cubes")
+            if isinstance(cubes, list) and cubes:
+                entry["cubes"] = _orient_legacy_cubes_to_side(
+                    cubes,
+                    bone_name=name,
+                    parent_name=entry.get("parent") if isinstance(entry.get("parent"), str) else None,
+                )
+                _filter_main_entry(entry)
+        return filtered
+
+    by_name = {
+        entry["name"]: entry
+        for entry in entries
+        if isinstance(entry.get("name"), str)
+    }
+    for entry in entries:
+        if entry.get("__compiled_cube_decode_mode") == "child_allocated":
+            if asset_name in {"arm_model", "arrow_model"}:
+                continue
+            cubes = entry.get("cubes")
+            best = (
+                _filter_format15_cube_list(
+                    cubes,
+                    bone_name=str(entry.get("name", "")),
+                    pivot=None,
+                )
+                if isinstance(cubes, list) and asset_name in {"arm_model", "arrow_model"}
+                else _best_format15_filter_context(entry, by_name)
+            )
+            if best:
+                entry["cubes"] = best
+            else:
+                entry.pop("cubes", None)
+            continue
+        _filter_format15_entry_cubes(entry)
+    if asset_name == "arm_model":
+        by_name = {
+            entry["name"]: entry
+            for entry in entries
+            if isinstance(entry.get("name"), str) and entry.get("name") in _FORMAT9_ARM_MODEL_KEEP_NAMES
+        }
+        filtered = [by_name[name] for name in arm_order if name in by_name]
+        by_name = {
+            entry["name"]: entry
+            for entry in filtered
+            if isinstance(entry.get("name"), str)
+        }
+        if "Arm" not in by_name and ("LeftArm" in by_name or "RightArm" in by_name):
+            arm_entry: dict[str, object] = {"name": "Arm"}
+            filtered.insert(0, arm_entry)
+            by_name["Arm"] = arm_entry
+        parent_map = {
+            "LeftArm": "Arm",
+            "RightArm": "Arm",
+            "LeftForeArm": "LeftArm",
+            "RightForeArm": "RightArm",
+            "LeftHand": "LeftForeArm",
+            "RightHand": "RightForeArm",
+            "LeftHandLocator": "LeftHand",
+            "RightHandLocator": "RightHand",
+        }
+        for child, parent in parent_map.items():
+            if child in by_name and parent in by_name:
+                by_name[child]["parent"] = parent
+        swapped: set[str] = set()
+        for name, entry in by_name.items():
+            if name in swapped:
+                continue
+            other_name = _format9_pair_name(name)
+            if other_name is None or other_name not in by_name:
+                continue
+            other = by_name[other_name]
+            x0 = _format9_entry_pivot_x(entry)
+            x1 = _format9_entry_pivot_x(other)
+            if x0 is None or x1 is None:
+                continue
+            if name.startswith("Left") and x0 < 0.0 and x1 > 0.0:
+                _swap_format9_entry_payload(entry, other)
+                swapped.add(name)
+                swapped.add(other_name)
+            elif name.startswith("Right") and x0 > 0.0 and x1 < 0.0:
+                _swap_format9_entry_payload(entry, other)
+                swapped.add(name)
+                swapped.add(other_name)
+        for name in arm_order:
+            if name in by_name:
+                continue
+            entry: dict[str, object] = {"name": name}
+            parent = parent_map.get(name)
+            if parent is not None:
+                entry["parent"] = parent
+            filtered.append(entry)
+            by_name[name] = entry
+        return filtered
+    if asset_name == "arrow_model":
+        by_name = {
+            entry["name"]: entry
+            for entry in entries
+            if isinstance(entry.get("name"), str) and entry.get("name") in _FORMAT9_ARROW_MODEL_KEEP_NAMES
+        }
+        filtered = [by_name[name] for name in arrow_order if name in by_name]
+        by_name = {
+            entry["name"]: entry
+            for entry in filtered
+            if isinstance(entry.get("name"), str)
+        }
+        parent_map = {
+            "UpPl": "Root",
+            "DownPl": "Root",
+            "LeftPl": "Root",
+            "RightPl": "Root",
+            "Other": "Root",
+            "Sakura": "Root",
+            "Bowknot": "Other",
+            "Bowknot2": "Other",
+            "Bowknot3": "Other",
+            "Bowknot4": "Other",
+            "Bowknot5": "Other",
+            "Board": "Other",
+            "Brand": "Other",
+            "Board2": "Board",
+        }
+        for child, parent in parent_map.items():
+            if child in by_name and parent in by_name:
+                by_name[child]["parent"] = parent
+        for name in arrow_order:
+            if name in by_name:
+                continue
+            entry = {"name": name}
+            parent = parent_map.get(name)
+            if parent is not None:
+                entry["parent"] = parent
+            filtered.append(entry)
+            by_name[name] = entry
+        return filtered
+    return entries
+
+
+def _swap_format9_entry_payload(a: dict[str, object], b: dict[str, object]) -> None:
+    for key in (
+        "pivot",
+        "cubes",
+        "__compiled_cube_count_guess",
+        "__compiled_wrapper_name",
+        "__compiled_uv_norm_hints",
+        "__compiled_cube_source",
+        "__compiled_cube_anchor_name",
+        "__compiled_cube_payload_name",
+        "__compiled_cube_payload_kind",
+        "__compiled_cube_decode_mode",
+        "__compiled_cube_rejected_reason",
+    ):
+        av = a.get(key)
+        bv = b.get(key)
+        if bv is None:
+            a.pop(key, None)
+        else:
+            a[key] = bv
+        if av is None:
+            b.pop(key, None)
+        else:
+            b[key] = av
+
+
+def _format9_entry_pivot_x(entry: dict[str, object]) -> float | None:
+    pivot = entry.get("pivot")
+    if isinstance(pivot, list) and len(pivot) == 3:
+        return float(pivot[0])
+    cubes = entry.get("cubes")
+    if isinstance(cubes, list) and cubes:
+        cube_pivot = cubes[0].get("pivot")
+        if isinstance(cube_pivot, list) and len(cube_pivot) == 3:
+            return float(cube_pivot[0])
+    return None
+
+
+def _format9_center_distance(
+    cube: dict[str, object],
+    pivot: list[float] | tuple[float, float, float] | None,
+) -> float | None:
+    center = _legacy_cube_center(cube)
+    if center is None or pivot is None:
+        return None
+    return math.sqrt(
+        (center[0] - float(pivot[0])) ** 2
+        + (center[1] - float(pivot[1])) ** 2
+        + (center[2] - float(pivot[2])) ** 2
+    )
+
+
+def _filter_format9_entry_cubes(entry: dict[str, object], *, pivot_override: object | None = None) -> None:
+    cubes = entry.get("cubes")
+    if not isinstance(cubes, list) or not cubes:
+        return
+    if entry.get("name") == "gui":
+        entry.pop("cubes", None)
+        return
+    pivot = entry.get("pivot") if pivot_override is None else pivot_override
+    keep: list[dict[str, object]] = []
+    for cube in cubes:
+        size = cube.get("size")
+        if not isinstance(size, list) or len(size) != 3:
+            continue
+        sx, sy, sz = (float(size[0]), float(size[1]), float(size[2]))
+        max_dim = max(sx, sy, sz)
+        min_dim = min(sx, sy, sz)
+        if max_dim > 48.0 or min_dim <= 0.0:
+            continue
+        uv_faces = cube.get("uv", {})
+        if isinstance(uv_faces, dict):
+            bad_uv = False
+            for face in uv_faces.values():
+                if not isinstance(face, dict):
+                    continue
+                uv = face.get("uv")
+                uv_size = face.get("uv_size")
+                if isinstance(uv, list) and len(uv) == 2 and (float(uv[0]) < 0.0 or float(uv[1]) < 0.0):
+                    bad_uv = True
+                    break
+                if isinstance(uv_size, list) and len(uv_size) == 2:
+                    if abs(float(uv_size[0])) > 48.0 or abs(float(uv_size[1])) > 48.0:
+                        bad_uv = True
+                        break
+            if bad_uv:
+                continue
+        dist = _format9_center_distance(cube, pivot)
+        if dist is not None and dist > max(18.0, max_dim * 1.75) and max_dim > 3.0:
+            continue
+        keep.append(cube)
+    if keep:
+        entry["cubes"] = keep
+    else:
+        entry.pop("cubes", None)
+
+
+def _postprocess_format9_model_entries(
+    entries: list[dict[str, object]],
+    *,
+    asset_name: str | None,
+) -> list[dict[str, object]]:
+    arm_order = (
+        "Arm",
+        "LeftArm",
+        "LeftForeArm",
+        "LeftHand",
+        "LeftHandLocator",
+        "RightArm",
+        "RightForeArm",
+        "RightHand",
+        "RightHandLocator",
+    )
+    arrow_order = (
+        "Root",
+        "UpPl",
+        "DownPl",
+        "LeftPl",
+        "RightPl",
+        "Other",
+        "Bowknot",
+        "Bowknot2",
+        "Bowknot3",
+        "Bowknot4",
+        "Bowknot5",
+        "Board",
+        "Board2",
+        "Brand",
+        "Sakura",
+    )
+    by_name = {
+        entry["name"]: entry
+        for entry in entries
+        if isinstance(entry.get("name"), str)
+    }
+
+    # Repair common missing visible-bone parents from the paired legacy sample.
+    explicit_parent_rules = {
+        "AllHead": "UpperBody",
+        "bow": "UpperBody",
+        "LeftEyelid": "Eyelid",
+        "RightEyelid": "Eyelid",
+        "LeftEyebrow": "EyeBrow",
+        "RightEyebrow": "EyeBrow",
+        "LeftEyePublic": "LeftEyelidBase",
+        "RightEyePublic": "RightEyelidBase",
+        "LeftEyeDot": "LeftEyelidBase",
+        "RightEyeDot": "RightEyelidBase",
+        "Left_ear": "Ear",
+        "Right_ear": "Ear",
+        "LeftArm": "Arm",
+        "RightArm": "Arm",
+        "LeftLeg": "Leg",
+        "RightLeg": "Leg",
+        "UpPl": "Root",
+        "DownPl": "Root",
+        "LeftPl": "Root",
+        "RightPl": "Root",
+        "Other": "Root",
+        "Sakura": "Root",
+        "Bowknot": "Other",
+        "Bowknot2": "Other",
+        "Bowknot3": "Other",
+        "Bowknot4": "Other",
+        "Bowknot5": "Other",
+        "Board": "Other",
+        "Brand": "Other",
+        "Board2": "Board",
+    }
+    for entry in entries:
+        name = entry.get("name")
+        if not isinstance(name, str):
+            continue
+        wrapper_parent = f"M{name}"
+        if wrapper_parent in by_name and (
+            entry.get("parent") is None or name in {"Head", "UpperBody", "UpBody", "AllBody", "Tail"}
+        ):
+            entry["parent"] = wrapper_parent
+            continue
+        if entry.get("parent") is not None:
+            continue
+        parent = explicit_parent_rules.get(name)
+        if parent is not None and parent in by_name:
+            entry["parent"] = parent
+
+    # Remove helper/container cubes that should live on visible children instead.
+    child_map: dict[str, list[str]] = {}
+    for entry in entries:
+        parent = entry.get("parent")
+        name = entry.get("name")
+        if isinstance(parent, str) and isinstance(name, str):
+            child_map.setdefault(parent, []).append(name)
+    for entry in entries:
+        name = entry.get("name")
+        if not isinstance(name, str) or "cubes" not in entry:
+            continue
+        if name.startswith("M") and name[1:] in by_name:
+            entry.pop("cubes", None)
+            continue
+        if name.endswith("Locator") or name in _FORMAT9_CONTAINER_BONE_NAMES:
+            children = child_map.get(name, [])
+            if any(by_name.get(child, {}).get("cubes") for child in children):
+                entry.pop("cubes", None)
+    if asset_name == "arm_model":
+        filtered = []
+        for entry in entries:
+            name = entry.get("name")
+            if isinstance(name, str) and name not in _FORMAT9_ARM_MODEL_KEEP_NAMES:
+                continue
+            filtered.append(entry)
+        entries = filtered
+        by_name = {
+            entry["name"]: entry
+            for entry in entries
+            if isinstance(entry.get("name"), str)
+        }
+        if "Arm" not in by_name and ("LeftArm" in by_name or "RightArm" in by_name):
+            arm_entry: dict[str, object] = {"name": "Arm"}
+            entries.insert(0, arm_entry)
+            by_name["Arm"] = arm_entry
+            for child_name in ("LeftArm", "RightArm"):
+                child = by_name.get(child_name)
+                if child is not None:
+                    child["parent"] = "Arm"
+            if "LeftForeArm" in by_name:
+                by_name["LeftForeArm"]["parent"] = "LeftArm"
+            if "RightForeArm" in by_name:
+                by_name["RightForeArm"]["parent"] = "RightArm"
+            if "LeftHand" in by_name:
+                by_name["LeftHand"]["parent"] = "LeftForeArm"
+            if "RightHand" in by_name:
+                by_name["RightHand"]["parent"] = "RightForeArm"
+            if "LeftHandLocator" in by_name:
+                by_name["LeftHandLocator"]["parent"] = "LeftHand"
+            if "RightHandLocator" in by_name:
+                by_name["RightHandLocator"]["parent"] = "RightHand"
+        parent_map = {
+            "LeftArm": "Arm",
+            "RightArm": "Arm",
+            "LeftForeArm": "LeftArm",
+            "RightForeArm": "RightArm",
+            "LeftHand": "LeftForeArm",
+            "RightHand": "RightForeArm",
+            "LeftHandLocator": "LeftHand",
+            "RightHandLocator": "RightHand",
+        }
+        for name in arm_order:
+            if name in by_name:
+                continue
+            entry = {"name": name}
+            parent = parent_map.get(name)
+            if parent is not None:
+                entry["parent"] = parent
+            entries.append(entry)
+            by_name[name] = entry
+    if asset_name == "arrow_model":
+        parent_map = {
+            "UpPl": "Root",
+            "DownPl": "Root",
+            "LeftPl": "Root",
+            "RightPl": "Root",
+            "Other": "Root",
+            "Sakura": "Root",
+            "Bowknot": "Other",
+            "Bowknot2": "Other",
+            "Bowknot3": "Other",
+            "Bowknot4": "Other",
+            "Bowknot5": "Other",
+            "Board": "Other",
+            "Brand": "Other",
+            "Board2": "Board",
+        }
+        by_name = {
+            entry["name"]: entry
+            for entry in entries
+            if isinstance(entry.get("name"), str)
+        }
+        for name in arrow_order:
+            if name in by_name:
+                continue
+            entry = {"name": name}
+            parent = parent_map.get(name)
+            if parent is not None:
+                entry["parent"] = parent
+            entries.append(entry)
+            by_name[name] = entry
+
+    # Keep only locally plausible cubes on visible bones.
+    for entry in entries:
+        if entry.get("__compiled_cube_decode_mode") == "child_allocated":
+            pivot_override = None
+            parent_name = entry.get("parent")
+            if isinstance(parent_name, str):
+                parent_entry = by_name.get(parent_name)
+                if parent_entry is not None:
+                    pivot_override = parent_entry.get("pivot")
+            anchor_name = entry.get("__compiled_cube_anchor_name")
+            if isinstance(anchor_name, str):
+                anchor_entry = by_name.get(anchor_name)
+                if anchor_entry is not None and pivot_override is None:
+                    pivot_override = anchor_entry.get("pivot")
+            _filter_format9_entry_cubes(entry, pivot_override=pivot_override)
+            continue
+        _filter_format9_entry_cubes(entry)
+
+    # If a left/right pair landed on the wrong side, swap the geometry payloads.
+    swapped: set[str] = set()
+    for name, entry in by_name.items():
+        if name in swapped:
+            continue
+        other_name = _format9_pair_name(name)
+        if other_name is None or other_name not in by_name:
+            continue
+        other = by_name[other_name]
+        x0 = _format9_entry_pivot_x(entry)
+        x1 = _format9_entry_pivot_x(other)
+        if x0 is None or x1 is None:
+            continue
+        if name.startswith("Left") and x0 < 0.0 and x1 > 0.0:
+            _swap_format9_entry_payload(entry, other)
+            swapped.add(name)
+            swapped.add(other_name)
+        elif name.startswith("Right") and x0 > 0.0 and x1 < 0.0:
+            _swap_format9_entry_payload(entry, other)
+            swapped.add(name)
+            swapped.add(other_name)
+        elif name.startswith("Left_") and x0 < 0.0 and x1 > 0.0:
+            _swap_format9_entry_payload(entry, other)
+            swapped.add(name)
+            swapped.add(other_name)
+        elif name.startswith("Right_") and x0 > 0.0 and x1 < 0.0:
+            _swap_format9_entry_payload(entry, other)
+            swapped.add(name)
+            swapped.add(other_name)
+
+    return entries
+
+
+def _png_chunk(tag: bytes, data: bytes) -> bytes:
+    return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", binascii.crc32(tag + data) & 0xFFFFFFFF)
+
+
+def _encode_png_rgba(width: int, height: int, rgba: bytes) -> bytes:
+    rows = []
+    stride = width * 4
+    for y in range(height):
+        rows.append(b"\x00" + rgba[y * stride:(y + 1) * stride])
+    raw = b"".join(rows)
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+    return b"".join(
+        (
+            b"\x89PNG\r\n\x1a\n",
+            _png_chunk(b"IHDR", ihdr),
+            _png_chunk(b"IDAT", zlib.compress(raw, level=9)),
+            _png_chunk(b"IEND", b""),
+        )
+    )
+
+
+def _png_pixels_equal(png_a: bytes, png_b: bytes) -> bool:
+    if png_a == png_b:
+        return True
+    if Image is None:
+        return False
+    try:
+        import io
+
+        img_a = Image.open(io.BytesIO(png_a)).convert("RGBA")
+        img_b = Image.open(io.BytesIO(png_b)).convert("RGBA")
+        return img_a.size == img_b.size and img_a.tobytes() == img_b.tobytes()
+    except Exception:
+        return False
+
+
+def _rgba_alpha_score(buf: bytes) -> float:
+    if len(buf) < 4:
+        return 0.0
+    alphas = buf[3::4]
+    if not alphas:
+        return 0.0
+    opaque_like = sum(1 for b in alphas if b in (0x00, 0xFF))
+    return opaque_like / len(alphas)
+
+
+def _decode_legacy_texture_variant_40(decoded: bytes, label_off: int, label: bytes) -> tuple[int, int, int, bytes] | None:
+    head_off = label_off + len(label)
+    head = decoded[head_off : head_off + 4]
+    if len(head) < 4 or head[2] != 0x40 or head[3] != 0x00:
+        return None
+    width = head[0] * 2
+    height = head[1]
+    if width <= 0 or height <= 0:
+        return None
+    payload_off = head_off + 99
+    payload_len = width * height * 8
+    payload = decoded[payload_off : payload_off + payload_len]
+    if len(payload) != payload_len:
+        return None
+    row_stride = width * 4
+    rows = [payload[i : i + row_stride] for i in range(0, payload_len, row_stride)]
+    if len(rows) != height * 2:
+        return None
+    merged = bytearray()
+    for even_row, odd_row in zip(rows[0::2], rows[1::2]):
+        for i in range(0, row_stride, 4):
+            a = even_row[i : i + 4]
+            b = odd_row[i : i + 4]
+            merged.extend(a if a[3] >= b[3] else b)
+    return (width, height, payload_off, bytes(merged))
+
+
+def _guess_legacy_texture_block(decoded: bytes, label_off: int, label: bytes, next_anchor: int | None) -> tuple[int, int] | None:
+    start = label_off + len(label) + 3
+    size_order = [512, 256, 128, 64, 32, 16]
+    lower = label.lower()
+    if lower == b"skin":
+        size_order = [256, 128, 64, 512, 32, 16]
+    elif b"arrow" in lower:
+        size_order = [64, 32, 128, 16, 256]
+
+    best: tuple[float, int, int] | None = None
+    for dim in size_order:
+        raw_len = dim * dim * 4
+        end = start + raw_len
+        if end > len(decoded):
+            continue
+        body = decoded[start:end]
+        body_score = _rgba_alpha_score(body)
+        if body_score < 0.70:
+            continue
+        tail = decoded[end:end + 256]
+        tail_score = _rgba_alpha_score(tail) if tail else 0.0
+        score = body_score - (tail_score * 0.35)
+        if next_anchor is not None:
+            gap = next_anchor - end
+            if 0 <= gap <= 16:
+                score += 0.75
+        if best is None or score > best[0]:
+            best = (score, dim, raw_len)
+    if best is None:
+        return None
+    return (best[1], best[2])
+
+
+def _export_legacy_textures(
+    decoded: bytes,
+    scan: LegacyScanResult,
+    out_dir: Path,
+    *,
+    debug: bool = False,
+    codec_format: int | None = None,
+) -> list[LegacyTextureExport]:
+    exports: list[LegacyTextureExport] = []
+    property_assets = parse_property_assets(scan_file(scan.path, dump=False).property_text)
+    texture_entries = [
+        entry
+        for entry in scan.directory_entries
+        if (
+            entry.property_match == "arrow_texture"
+            or (entry.property_match or "").startswith("texture")
+            or (entry.property_match or "").lower().endswith((".png", ".jpg", ".jpeg", ".tga"))
+        )
+    ]
+    if not texture_entries:
+        for asset in property_assets:
+            display_name = asset.display_name
+            if asset.tag != "texture" and not asset.tag.lower().endswith((".png", ".jpg", ".jpeg", ".tga")):
+                continue
+            if display_name != "arrow_texture" and not display_name.startswith("texture") and not asset.tag.lower().endswith((".png", ".jpg", ".jpeg", ".tga")):
+                continue
+            texture_entries.append(
+                LegacyDirectoryEntry(
+                    offset=-1,
+                    control=tuple(),
+                    name=asset.label or asset.tag,
+                    hash_hex=asset.hash_hex,
+                    property_match=display_name,
+                )
+            )
+    texture_entry_by_match = {entry.property_match: entry for entry in texture_entries if entry.property_match}
+    for asset in property_assets:
+        display_name = asset.display_name
+        if display_name in texture_entry_by_match:
+            continue
+        if asset.tag == "arrow_texture" or display_name == "arrow_texture":
+            texture_entries.append(
+                LegacyDirectoryEntry(
+                    offset=-1,
+                    control=tuple(),
+                    name=asset.label or asset.tag,
+                    hash_hex=asset.hash_hex,
+                    property_match="arrow_texture",
+                )
+            )
+            continue
+        if asset.tag == "texture" or display_name.startswith("texture") or asset.tag.lower().endswith((".png", ".jpg", ".jpeg", ".tga")):
+            texture_entries.append(
+                LegacyDirectoryEntry(
+                    offset=-1,
+                    control=tuple(),
+                    name=asset.label or asset.tag,
+                    hash_hex=asset.hash_hex,
+                    property_match=display_name,
+                )
+            )
+    def texture_labels(entry: LegacyDirectoryEntry) -> list[bytes]:
+        asset_name = entry.property_match or ""
+        raw_name = entry.name or ""
+        labels: list[str] = []
+        if raw_name:
+            labels.append(raw_name)
+        if asset_name == "arrow_texture":
+            labels.append("arrow")
+        elif asset_name.startswith("texture_"):
+            labels.append(asset_name[len("texture_"):])
+        deduped: list[bytes] = []
+        seen: set[bytes] = set()
+        for text in labels:
+            label = text.encode("ascii", "replace")
+            if not label or label in seen:
+                continue
+            seen.add(label)
+            deduped.append(label)
+        return deduped
+
+    label_offsets: dict[str, int] = {}
+    for entry in texture_entries:
+        for label in texture_labels(entry):
+            off = decoded.find(label)
+            if off >= 0:
+                label_offsets[entry.property_match or ""] = off
+                break
+
+    sorted_offsets = sorted(label_offsets.values())
+    for entry in texture_entries:
+        asset_name = entry.property_match or ""
+        labels = texture_labels(entry)
+        if not asset_name or not labels:
+            continue
+        label_off = label_offsets.get(asset_name)
+        if label_off is None:
+            continue
+        label = next((item for item in labels if decoded.find(item) == label_off), labels[0])
+        next_anchor = None
+        for off in sorted_offsets:
+            if off > label_off:
+                next_anchor = off
+                break
+        special = _decode_legacy_texture_variant_40(decoded, label_off, label)
+        if special is not None:
+            width, height, start, rgba = special
+            png = _encode_png_rgba(width, height, rgba)
+            png_sha256 = hashlib.sha256(png).hexdigest()
+            png_file = canonical_legacy_export_name(asset_name, "")
+            (out_dir / png_file).write_bytes(png)
+            exports.append(
+                LegacyTextureExport(
+                    asset_name=asset_name,
+                    label=label.decode("ascii", "replace"),
+                    width=width,
+                    height=height,
+                    offset=start,
+                    raw_len=len(rgba),
+                    png_file=png_file,
+                    sha256=png_sha256,
+                )
+            )
+            continue
+        guessed = _guess_legacy_texture_block(decoded, label_off, label, next_anchor)
+        if guessed is None:
+            continue
+        dim, raw_len = guessed
+        start = label_off + len(label) + 3
+        rgba = decoded[start:start + raw_len]
+        png = _encode_png_rgba(dim, dim, rgba)
+        png_sha256 = hashlib.sha256(png).hexdigest()
+        png_file = canonical_legacy_export_name(asset_name, "")
+        (out_dir / png_file).write_bytes(png)
+        exports.append(
+            LegacyTextureExport(
+                asset_name=asset_name,
+                label=label.decode("ascii", "replace"),
+                width=dim,
+                height=dim,
+                offset=start,
+                raw_len=raw_len,
+                png_file=png_file,
+                sha256=png_sha256,
+            )
+        )
+    return exports
+
+
+def _guess_legacy_texture_block_from_section(section: bytes) -> tuple[int, int] | None:
+    best: tuple[float, int, int] | None = None
+    for dim in (256, 128, 64):
+        raw_len = dim * dim * 4
+        if raw_len > len(section):
+            continue
+        for rel_off in range(0, len(section) - raw_len + 1, 0x100):
+            body = section[rel_off : rel_off + raw_len]
+            alpha = body[3::4]
+            if not alpha:
+                continue
+            alpha_discrete = sum(1 for b in alpha if b in (0, 255)) / len(alpha)
+            if alpha_discrete < 0.98:
+                continue
+            alpha_nonzero = sum(1 for b in alpha if b) / len(alpha)
+            if alpha_nonzero < 0.01:
+                continue
+            rgb_nonzero = sum(1 for b in body[0::4] if b) / len(alpha)
+            score = alpha_discrete + (alpha_nonzero * 3.0) + rgb_nonzero
+            if best is None or score > best[0]:
+                best = (score, dim, rel_off)
+    if best is None:
+        return None
+    return (best[1], best[2])
+
+
+def _export_legacy_textures_fallback(decoded: bytes, scan: LegacyScanResult, out_dir: Path) -> list[LegacyTextureExport]:
+    assets = parse_property_assets(scan_file(scan.path, dump=False).property_text)
+    texture_assets = [
+        asset
+        for asset in assets
+        if asset.tag == "texture" or asset.tag.lower().endswith((".png", ".jpg", ".jpeg", ".tga"))
+    ]
+    if not texture_assets:
+        return []
+    unnamed_sections = [
+        sec
+        for sec in scan.sections
+        if sec.asset_guess is None and sec.kind_guess in ("model", "texture_or_binary", "unknown")
+    ]
+    if not unnamed_sections:
+        return []
+    target_section = max(unnamed_sections, key=lambda sec: sec.size)
+    section_bytes = decoded[target_section.start : target_section.end]
+    guessed = _guess_legacy_texture_block_from_section(section_bytes)
+    if guessed is None:
+        return []
+    dim, rel_off = guessed
+    raw_len = dim * dim * 4
+    start = target_section.start + rel_off
+    rgba = decoded[start : start + raw_len]
+    png = _encode_png_rgba(dim, dim, rgba)
+    asset = texture_assets[0]
+    png_file = canonical_legacy_export_name(asset.display_name, "")
+    (out_dir / png_file).write_bytes(png)
+    return [
+        LegacyTextureExport(
+            asset_name=asset.display_name,
+            label=asset.label or asset.display_name,
+            width=dim,
+            height=dim,
+            offset=start,
+            raw_len=raw_len,
+            png_file=png_file,
+            sha256=hashlib.sha256(png).hexdigest(),
+        )
+    ]
+    return {
+        "format_version": "1.8.0",
+        "__compiled_decompile": {
+            "status": "signature_only",
+            "asset_name": asset_name,
+            "section_sha256": section_sha256,
+            "clip_count_guess": len(token_names),
+            "bone_name_count_guess": len(guessed_bones),
+            "signature_score": int(signature_scores.get(asset_name, 0)),
+            "notes": [
+                "Recovered from compiled legacy YSM animation section.",
+                "Clip names are inferred from embedded signature tokens.",
+                "Durations, loop modes, and keyframe channels are not reconstructed yet.",
+                "Bone lists are guessed from embedded strings.",
+            ],
+        },
+        "animations": animations,
+    }
+
+
+def _find_directory_start(decoded: bytes, tail_start: int) -> int:
+    window_start = max(0, tail_start - 0x40)
+    marker = decoded.rfind(b"\x80\x01\x80\x01", tail_start, min(len(decoded), tail_start + 0x80000))
+    if marker >= 0:
+        return marker
+    marker = decoded.rfind(b"\x80\x01\x80\x01", window_start, tail_start)
+    if marker >= 0:
+        return marker
+    return tail_start
+
+
+def _parse_legacy_directory(
+    decoded: bytes, directory_start: int, property_by_hash: dict[str, str]
+) -> tuple[str, tuple[LegacyDirectoryEntry, ...]]:
+    if directory_start >= len(decoded):
+        return "", tuple()
+    off = directory_start
+    prefix = ""
+    if decoded[off : off + 4] == b"\x80\x01\x80\x01":
+        prefix = decoded[off : off + 4].hex()
+        off += 4
+
+    entries: list[LegacyDirectoryEntry] = []
+    while off < len(decoded):
+        ctrl: tuple[int, ...]
+        name = ""
+        hash_off: int | None = None
+
+        if (
+            off + 66 <= len(decoded)
+            and decoded[off + 1] == 0x40
+            and HEX_HASH_RE.fullmatch(decoded[off + 2 : off + 66])
+        ):
+            ctrl = (decoded[off],)
+            hash_off = off + 2
+            next_off = off + 66
+        elif (
+            off + 67 <= len(decoded)
+            and decoded[off + 2] == 0x40
+            and HEX_HASH_RE.fullmatch(decoded[off + 3 : off + 67])
+        ):
+            ctrl = (decoded[off], decoded[off + 1])
+            hash_off = off + 3
+            next_off = off + 67
+        elif off + 3 <= len(decoded):
+            name_len = decoded[off + 1]
+            name_end = off + 2 + name_len
+            if (
+                0 < name_len < 0x40
+                and name_end + 65 <= len(decoded)
+                and decoded[name_end] == 0x40
+                and HEX_HASH_RE.fullmatch(decoded[name_end + 1 : name_end + 65])
+            ):
+                ctrl = (decoded[off], decoded[off + 1])
+                name = decoded[off + 2 : name_end].decode("utf-8", "replace")
+                hash_off = name_end + 1
+                next_off = name_end + 65
+            else:
+                break
+        else:
+            break
+
+        hash_hex = decoded[hash_off : hash_off + 64].decode("ascii")
+        entries.append(
+            LegacyDirectoryEntry(
+                offset=off,
+                control=ctrl,
+                name=name,
+                hash_hex=hash_hex,
+                property_match=property_by_hash.get(hash_hex),
+            )
+        )
+        off = next_off
+
+    return prefix, tuple(entries)
+
+
+def find_legacy_sections(decoded: bytes, tail_start: int) -> list[LegacySection]:
+    starts = {0}
+    for pat in SECTION_TAGS:
+        start = 0
+        while True:
+            i = decoded.find(pat, start)
+            if i < 0 or i >= tail_start:
+                break
+            starts.add(i)
+            start = i + 1
+    ordered = sorted(starts)
+    filtered: list[int] = []
+    for s in ordered:
+        if not filtered or s - filtered[-1] > 0x800:
+            filtered.append(s)
+    filtered.append(tail_start)
+
+    sections: list[LegacySection] = []
+    for i, start in enumerate(filtered[:-1]):
+        end = filtered[i + 1]
+        if end <= start:
+            continue
+        chunk = decoded[start:end]
+        if len(chunk) < 0x800:
+            continue
+        names = _extract_names(chunk)
+        kind = _classify_section(chunk, names)
+        sections.append(
+            LegacySection(
+                start=start,
+                end=end,
+                size=end - start,
+                tag=int.from_bytes(chunk[:4], "little"),
+                kind_guess=kind,
+                names=names,
+                asset_guess=None,
+                assignment_method=None,
+                sha256=hashlib.sha256(chunk).hexdigest(),
+            )
+        )
+    return sections
+
+
+def assign_property_names(
+    sections: list[LegacySection],
+    path: Path,
+    decoded: bytes,
+    codec_format: int | None,
+    directory_entries: tuple[LegacyDirectoryEntry, ...],
+) -> tuple[list[LegacySection], tuple[str, ...]]:
+    expected_by_kind = _expected_legacy_assets_by_kind(path, codec_format, directory_entries)
+    expected_assets = tuple(name for values in expected_by_kind.values() for name in values)
+
+    rows = [
+        {
+            "section": sec,
+            "asset_guess": None,
+            "assignment_method": None,
+        }
+        for sec in sections
+    ]
+    assigned_assets: set[str] = set()
+
+    def assign_index(idx: int, asset_name: str, method: str) -> None:
+        if rows[idx]["asset_guess"] is not None or asset_name in assigned_assets:
+            return
+        rows[idx]["asset_guess"] = asset_name
+        rows[idx]["assignment_method"] = method
+        assigned_assets.add(asset_name)
+
+    def unassigned_indexes(*, kind: str | None = None) -> list[int]:
+        indexes: list[int] = []
+        for idx, row in enumerate(rows):
+            sec = row["section"]
+            if row["asset_guess"] is not None:
+                continue
+            if kind is not None and sec.kind_guess != kind:
+                continue
+            indexes.append(idx)
+        return indexes
+
+    for kind in ("model", "audio", "texture_or_binary"):
+        pool = list(expected_by_kind.get(kind, ()))
+        for idx in unassigned_indexes(kind=kind):
+            if not pool:
+                break
+            assign_index(idx, pool.pop(0), "kind_order")
+
+    animation_assets = [name for name in expected_by_kind.get("animation", ()) if name not in assigned_assets]
+    signature_candidates = [
+        idx
+        for idx in unassigned_indexes()
+        if rows[idx]["section"].kind_guess != "audio"
+    ]
+    for asset_name in animation_assets:
+        scored: list[tuple[int, int]] = []
+        for idx in signature_candidates:
+            sec = rows[idx]["section"]
+            score = int(_legacy_signature_scores(decoded[sec.start : sec.end]).get(asset_name, 0))
+            if score > 0:
+                scored.append((score, idx))
+        scored.sort(reverse=True)
+        if not scored:
+            continue
+        best_score, best_idx = scored[0]
+        second_score = scored[1][0] if len(scored) > 1 else -1
+        if best_score >= 2 and best_score > second_score:
+            assign_index(best_idx, asset_name, "signature")
+            signature_candidates = [idx for idx in signature_candidates if idx != best_idx]
+
+    for idx in unassigned_indexes(kind="animation"):
+        pool = [name for name in expected_by_kind.get("animation", ()) if name not in assigned_assets]
+        if not pool:
+            break
+        assign_index(idx, pool.pop(0), "kind_order")
+
+    assigned_sections: list[LegacySection] = []
+    for row in rows:
+        sec = row["section"]
+        assigned_sections.append(
+            LegacySection(
+                start=sec.start,
+                end=sec.end,
+                size=sec.size,
+                tag=sec.tag,
+                kind_guess=sec.kind_guess,
+                names=sec.names,
+                asset_guess=row["asset_guess"],
+                assignment_method=row["assignment_method"],
+                sha256=sec.sha256,
+            )
+        )
+    return assigned_sections, expected_assets
+
+
+def scan_legacy_sections(path: Path) -> LegacyScanResult:
+    result = decode_bom_v3(path)
+    decoded = result.decompressed
+    tail_markers = [m.start() for m in HEX_HASH_RE.finditer(decoded)]
+    tail_start = min(tail_markers) if tail_markers else len(decoded)
+    directory_start = _find_directory_start(decoded, tail_start)
+    property_assets = parse_property_assets(scan_file(path, dump=False).property_text)
+    codec_format = _read_property_format(path)
+    property_by_hash = {asset.hash_hex: asset.display_name for asset in property_assets}
+    directory_prefix, directory_entries = _parse_legacy_directory(decoded, directory_start, property_by_hash)
+    sections, expected_assets = assign_property_names(
+        find_legacy_sections(decoded, tail_start),
+        path,
+        decoded,
+        codec_format,
+        directory_entries,
+    )
+    return LegacyScanResult(
+        path=path,
+        codec_format=codec_format,
+        decoded_len=len(decoded),
+        tail_start=tail_start,
+        directory_start=directory_start,
+        directory_prefix=directory_prefix,
+        directory_entries=directory_entries,
+        expected_assets=expected_assets,
+        sections=tuple(sections),
+    )
+
+
+def _prune_legacy_debug_outputs(out_dir: Path) -> None:
+    for pattern in ("*.section.bin", "*.manifest.json", "*.decompiled.json"):
+        for path in out_dir.glob(pattern):
+            path.unlink(missing_ok=True)
+
+
+def _clear_legacy_output_dir(out_dir: Path) -> None:
+    for pattern in (
+        "*.json",
+        "*.png",
+        "*.ogg",
+        "*.section.bin",
+        "*.manifest.json",
+        "*.decompiled.json",
+        "property.txt",
+        "decoded.bin",
+        "asset_bundle.json",
+        "legacy_sections.json",
+        "oracle_restore.json",
+    ):
+        for path in out_dir.glob(pattern):
+            path.unlink(missing_ok=True)
+
+
+def dump_legacy_sections(
+    path: Path,
+    scan: LegacyScanResult | None = None,
+    *,
+    debug: bool = False,
+    out_dir: Path | None = None,
+) -> Path:
+    if scan is None:
+        scan = scan_legacy_sections(path)
+    result = decode_bom_v3(path)
+    decoded = result.decompressed
+
+    folder_name = _sanitize_name(_read_property_name(path) or path.stem)
+    codec_format = scan.codec_format
+    out_dir = out_dir or path.with_name(f"{folder_name}_legacy_sections_format{codec_format or 'unknown'}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    _clear_legacy_output_dir(out_dir)
+
+    manifest = {
+        "source_file": str(path),
+        "codec_format": codec_format,
+        "decoded_len": scan.decoded_len,
+        "tail_start": scan.tail_start,
+        "directory_start": scan.directory_start,
+        "directory_prefix": scan.directory_prefix,
+        "directory_count": len(scan.directory_entries),
+        "directory_entries": [
+            {
+                "offset": entry.offset,
+                "control": list(entry.control),
+                "name": entry.name,
+                "hash_hex": entry.hash_hex,
+                "property_match": entry.property_match,
+            }
+            for entry in scan.directory_entries
+        ],
+        "section_count": len(scan.sections),
+        "expected_assets": list(scan.expected_assets),
+        "resolved_assets": [],
+        "unresolved_assets": [],
+        "texture_exports": [],
+        "pretty_aliases": [],
+        "sections": [],
+    }
+
+    used_aliases: set[str] = set()
+    section_bytes_by_name: dict[str, bytes] = {}
+    alias_candidates: list[dict[str, object]] = []
+    format9_arrow_section = _select_format9_arrow_section(scan, decoded) if codec_format == 9 else None
+
+    for idx, sec in enumerate(scan.sections):
+        base = sec.asset_guess or f"legacy_{idx:02d}.{sec.kind_guess}"
+        file_name = f"{_sanitize_name(base.replace('_', '.'))}.section.bin"
+        out_path = out_dir / file_name
+        section_bytes = decoded[sec.start:sec.end]
+        out_path.write_bytes(section_bytes)
+        section_bytes_by_name[file_name] = section_bytes
+        if sec.asset_guess is not None:
+            used_aliases.add(file_name)
+        animation_headers = list(_parse_animation_headers(section_bytes)) if sec.kind_guess == "animation" else []
+        ogg_off = section_bytes.find(b"OggS") if sec.kind_guess == "audio" else -1
+        ogg_file = None
+        if ogg_off >= 0:
+            should_export_ogg = debug or (
+                sec.asset_guess is not None and legacy_asset_category(sec.asset_guess)[0] == "sound"
+            )
+            if should_export_ogg:
+                if sec.asset_guess and legacy_asset_category(sec.asset_guess)[0] == "sound":
+                    ogg_base = canonical_legacy_export_name(sec.asset_guess, "").rsplit(".", 1)[0]
+                else:
+                    ogg_base = _sanitize_name(base.replace("_", "."))
+                ogg_name = f"{ogg_base}.ogg"
+                ogg_stream = _extract_ogg_stream(decoded, sec.start + ogg_off)
+                (out_dir / ogg_name).write_bytes(ogg_stream if ogg_stream is not None else section_bytes[ogg_off:])
+                ogg_file = ogg_name
+            if sec.asset_guess and legacy_asset_category(sec.asset_guess)[0] == "sound" and should_export_ogg:
+                manifest["resolved_assets"].append(sec.asset_guess)
+        if sec.asset_guess is None:
+            score_blob = section_bytes
+            source_file = file_name
+            source_offset = 0
+            if ogg_off > 0x1000:
+                prefix_name = f"{_sanitize_name(base.replace('_', '.'))}.prefix.section.bin"
+                (out_dir / prefix_name).write_bytes(section_bytes[:ogg_off])
+                section_bytes_by_name[prefix_name] = section_bytes[:ogg_off]
+                score_blob = section_bytes[:ogg_off]
+                source_file = prefix_name
+                source_offset = 0
+            alias_candidates.append(
+                {
+                    "ordinal": idx,
+                    "source_file": source_file,
+                    "source_offset": source_offset,
+                    "scores": _legacy_signature_scores(score_blob),
+                }
+            )
+        entry = {
+            "ordinal": idx,
+            "asset_guess": sec.asset_guess,
+            "assignment_method": sec.assignment_method,
+            "kind_guess": sec.kind_guess,
+            "tag": sec.tag,
+            "start": sec.start,
+            "end": sec.end,
+            "size": sec.size,
+            "sha256": sec.sha256,
+            "file": file_name,
+            "names": list(sec.names),
+            "animation_headers": animation_headers,
+            "ogg_offset": ogg_off if ogg_off >= 0 else None,
+            "ogg_file": ogg_file,
+            "signature_scores": _legacy_signature_scores(section_bytes if ogg_off < 0 else section_bytes[:ogg_off] if ogg_off > 0x1000 else section_bytes),
+        }
+        manifest["sections"].append(entry)
+        per_section_manifest = {
+            "source_file": str(path),
+            "codec_format": codec_format,
+            "directory_start": scan.directory_start,
+            "ordinal": idx,
+            "asset_guess": sec.asset_guess,
+            "assignment_method": sec.assignment_method,
+            "kind_guess": sec.kind_guess,
+            "tag": sec.tag,
+            "start": sec.start,
+            "end": sec.end,
+            "size": sec.size,
+            "sha256": sec.sha256,
+            "file": file_name,
+            "names": list(sec.names),
+            "animation_headers": animation_headers,
+            "ogg_offset": ogg_off if ogg_off >= 0 else None,
+            "ogg_file": ogg_file,
+            "signature_scores": entry["signature_scores"],
+        }
+        (out_dir / f"{file_name}.manifest.json").write_text(
+            json.dumps(per_section_manifest, indent=2), encoding="utf-8"
+        )
+        if sec.asset_guess and legacy_asset_category(sec.asset_guess)[0] == "animation":
+            if animation_headers:
+                stub = build_animation_decompile_stub(
+                    asset_name=sec.asset_guess,
+                    section_sha256=sec.sha256,
+                    names=sec.names,
+                    animation_headers=animation_headers,
+                )
+                stub = _augment_legacy_animation_stub(sec.asset_guess, stub)
+            else:
+                stub = _build_legacy_animation_signature_stub(
+                    asset_name=sec.asset_guess,
+                    section_sha256=sec.sha256,
+                    names=sec.names,
+                    signature_scores=entry["signature_scores"],
+                )
+                stub = _augment_legacy_animation_stub(sec.asset_guess, stub)
+            stub_text = json.dumps(stub, indent=2)
+            if debug:
+                (out_dir / _canonical_animation_stub_name(file_name)).write_text(
+                    stub_text, encoding="utf-8"
+                )
+            canonical_name = _canonical_legacy_json_name(sec.asset_guess, "animation")
+            if canonical_name is not None:
+                (out_dir / canonical_name).write_text(
+                    json.dumps(_strip_private_fields(stub), indent=2),
+                    encoding="utf-8",
+                )
+                manifest["resolved_assets"].append(sec.asset_guess)
+        elif sec.asset_guess and legacy_asset_category(sec.asset_guess)[0] == "model":
+            stub = build_model_decompile_stub(
+                asset_name=sec.asset_guess or base,
+                section_sha256=sec.sha256,
+                names=sec.names,
+            )
+            if debug:
+                stub_text = json.dumps(stub, indent=2)
+                (out_dir / _canonical_model_stub_name(file_name)).write_text(
+                    stub_text, encoding="utf-8"
+                )
+            canonical_name = _canonical_legacy_json_name(sec.asset_guess or "", "model")
+            if canonical_name is not None:
+                selected_idx, selected_sec = _select_legacy_model_source_section(
+                    scan,
+                    decoded,
+                    current_index=idx,
+                    asset_name=sec.asset_guess,
+                    codec_format=codec_format,
+                )
+                geometry_section = decoded[selected_sec.start : selected_sec.end]
+                canonical_section = decoded[sec.start : sec.end]
+                canonical_names = sec.names
+                if (
+                    selected_idx == idx
+                    and codec_format == 9
+                    and sec.asset_guess == "arrow_model"
+                    and format9_arrow_section is not None
+                ):
+                    geometry_section = decoded[format9_arrow_section.start : format9_arrow_section.end]
+                canonical_stub = _build_legacy_model_canonical_json(
+                    sec.asset_guess,
+                    canonical_section,
+                    canonical_names,
+                    codec_format=codec_format,
+                    geometry_section=geometry_section,
+                )
+                model_summary = _summarize_legacy_model_stub(canonical_stub)
+                (out_dir / canonical_name).write_text(
+                    json.dumps(_strip_private_fields(canonical_stub), indent=2), encoding="utf-8"
+                )
+                entry["model_source_section_ordinal"] = selected_idx
+                entry["model_source_asset_guess"] = selected_sec.asset_guess
+                entry["model_typed_bone_hits"] = model_summary["typed_bone_hits"]
+                entry["model_fallback_bone_hits"] = model_summary["fallback_bone_hits"]
+                entry["model_segmented_record_hits"] = model_summary["segmented_record_bone_hits"]
+                entry["model_child_allocated_bone_hits"] = model_summary["child_allocated_bone_hits"]
+                entry["model_repaired_parent_bones"] = model_summary["repaired_parent_bones"]
+                entry["model_head_child_allocations"] = model_summary["head_child_allocations"]
+                entry["model_mask_child_allocated_bone_hits"] = model_summary["mask_child_allocated_bone_hits"]
+                entry["model_head_structural_repairs"] = model_summary["head_structural_repairs"]
+                entry["model_ear_child_allocations"] = model_summary["ear_child_allocations"]
+                entry["model_foot_child_allocations"] = model_summary["foot_child_allocations"]
+                entry["model_leg_child_allocations"] = model_summary["leg_child_allocations"]
+                entry["model_tail_child_allocations"] = model_summary["tail_child_allocations"]
+                entry["model_body_child_allocations"] = model_summary["body_child_allocations"]
+                entry["model_hair_child_allocations"] = model_summary["hair_child_allocations"]
+                entry["model_mouth_child_allocations"] = model_summary["mouth_child_allocations"]
+                entry["model_arm_child_allocations"] = model_summary["arm_child_allocations"]
+                entry["model_fanout_group_rejections"] = model_summary["fanout_group_rejections"]
+                entry["model_container_parent_rejections"] = model_summary["container_parent_rejections"]
+                entry["model_semantic_stage"] = model_summary["semantic_stage"]
+                if sec.asset_guess:
+                    manifest["resolved_assets"].append(sec.asset_guess)
+
+    for asset_name in LEGACY_SIGNATURES:
+        scored = sorted(
+            (
+                (
+                    int(candidate["scores"].get(asset_name, 0)),
+                    int(candidate["ordinal"]),
+                    candidate["source_file"],
+                )
+                for candidate in alias_candidates
+                if int(candidate["scores"].get(asset_name, 0)) > 0
+            ),
+            reverse=True,
+        )
+        if not scored:
+            continue
+        best_score, best_ordinal, best_source = scored[0]
+        second_score = scored[1][0] if len(scored) > 1 else -1
+        if best_score < 2 or best_score <= second_score:
+            continue
+        alias_name = f"{asset_name.replace('_', '.')}.section.bin"
+        if alias_name in used_aliases:
+            continue
+        data = section_bytes_by_name.get(best_source)
+        if data is None:
+            continue
+        (out_dir / alias_name).write_bytes(data)
+        used_aliases.add(alias_name)
+        source_entry = manifest["sections"][best_ordinal]
+        if legacy_asset_category(asset_name)[0] == "animation":
+            if source_entry["animation_headers"]:
+                stub = build_animation_decompile_stub(
+                    asset_name=asset_name,
+                    section_sha256=str(source_entry["sha256"]),
+                    names=tuple(str(n) for n in source_entry["names"]),
+                    animation_headers=source_entry["animation_headers"],
+                )
+                stub = _augment_legacy_animation_stub(asset_name, stub)
+            else:
+                stub = _build_legacy_animation_signature_stub(
+                    asset_name=asset_name,
+                    section_sha256=str(source_entry["sha256"]),
+                    names=tuple(str(n) for n in source_entry["names"]),
+                    signature_scores=dict(source_entry["signature_scores"]),
+                )
+                stub = _augment_legacy_animation_stub(asset_name, stub)
+            stub_text = json.dumps(stub, indent=2)
+            if debug:
+                (out_dir / _canonical_animation_stub_name(alias_name)).write_text(
+                    stub_text, encoding="utf-8"
+                )
+            canonical_name = _canonical_legacy_json_name(asset_name, "animation")
+            if canonical_name is not None:
+                (out_dir / canonical_name).write_text(
+                    json.dumps(_strip_private_fields(stub), indent=2),
+                    encoding="utf-8",
+                )
+                manifest["resolved_assets"].append(asset_name)
+        elif legacy_asset_category(asset_name)[0] == "model":
+            stub = build_model_decompile_stub(
+                asset_name=asset_name,
+                section_sha256=str(source_entry["sha256"]),
+                names=tuple(str(n) for n in source_entry["names"]),
+            )
+            if debug:
+                stub_text = json.dumps(stub, indent=2)
+                (out_dir / _canonical_model_stub_name(alias_name)).write_text(
+                    stub_text, encoding="utf-8"
+                )
+            canonical_name = _canonical_legacy_json_name(asset_name, "model")
+            if canonical_name is not None:
+                data = section_bytes_by_name.get(alias_name)
+                if data is not None:
+                    canonical_stub = _build_legacy_model_canonical_json(
+                        asset_name,
+                        data,
+                        tuple(str(n) for n in source_entry["names"]),
+                        codec_format=codec_format,
+                        geometry_section=data,
+                    )
+                    model_summary = _summarize_legacy_model_stub(canonical_stub)
+                    (out_dir / canonical_name).write_text(
+                        json.dumps(_strip_private_fields(canonical_stub), indent=2), encoding="utf-8"
+                    )
+                    source_entry["model_typed_bone_hits"] = model_summary["typed_bone_hits"]
+                    source_entry["model_fallback_bone_hits"] = model_summary["fallback_bone_hits"]
+                    source_entry["model_segmented_record_hits"] = model_summary["segmented_record_bone_hits"]
+                    source_entry["model_child_allocated_bone_hits"] = model_summary["child_allocated_bone_hits"]
+                    source_entry["model_repaired_parent_bones"] = model_summary["repaired_parent_bones"]
+                    source_entry["model_head_child_allocations"] = model_summary["head_child_allocations"]
+                    source_entry["model_mask_child_allocated_bone_hits"] = model_summary["mask_child_allocated_bone_hits"]
+                    source_entry["model_head_structural_repairs"] = model_summary["head_structural_repairs"]
+                    source_entry["model_ear_child_allocations"] = model_summary["ear_child_allocations"]
+                    source_entry["model_foot_child_allocations"] = model_summary["foot_child_allocations"]
+                    source_entry["model_leg_child_allocations"] = model_summary["leg_child_allocations"]
+                    source_entry["model_tail_child_allocations"] = model_summary["tail_child_allocations"]
+                    source_entry["model_body_child_allocations"] = model_summary["body_child_allocations"]
+                    source_entry["model_hair_child_allocations"] = model_summary["hair_child_allocations"]
+                    source_entry["model_mouth_child_allocations"] = model_summary["mouth_child_allocations"]
+                    source_entry["model_arm_child_allocations"] = model_summary["arm_child_allocations"]
+                    source_entry["model_fanout_group_rejections"] = model_summary["fanout_group_rejections"]
+                    source_entry["model_container_parent_rejections"] = model_summary["container_parent_rejections"]
+                    source_entry["model_semantic_stage"] = model_summary["semantic_stage"]
+                    manifest["resolved_assets"].append(asset_name)
+        manifest["pretty_aliases"].append(
+            {
+                "asset_name": asset_name,
+                "alias_file": alias_name,
+                "source_file": best_source,
+                "source_section_ordinal": best_ordinal,
+                "score": best_score,
+            }
+        )
+
+    texture_exports = _export_legacy_textures(
+        decoded,
+        scan,
+        out_dir,
+        debug=debug,
+        codec_format=codec_format,
+    )
+    if debug and not texture_exports:
+        texture_exports = _export_legacy_textures_fallback(decoded, scan, out_dir)
+    if not texture_exports:
+        for stale_name in {
+            "texture.png",
+            "texture.2.png",
+            *(canonical_legacy_export_name(asset_name, "") for asset_name in scan.expected_assets if legacy_asset_category(asset_name)[0] == "texture"),
+        }:
+            (out_dir / stale_name).unlink(missing_ok=True)
+    manifest["texture_exports"] = [
+        {
+            "asset_name": item.asset_name,
+            "label": item.label,
+            "width": item.width,
+            "height": item.height,
+            "offset": item.offset,
+            "raw_len": item.raw_len,
+            "png_file": item.png_file,
+            "sha256": item.sha256,
+        }
+        for item in texture_exports
+    ]
+    manifest["resolved_assets"].extend(item.asset_name for item in texture_exports)
+    texture_sizes = {item.asset_name: (item.width, item.height) for item in texture_exports}
+    main_tex_asset = next((name for name in texture_sizes if name != "arrow_texture"), None)
+    for model_file, asset_name in (
+        ("main.json", main_tex_asset),
+        ("arm.json", main_tex_asset),
+        ("arrow.json", "arrow_texture"),
+    ):
+        tex = texture_sizes.get(asset_name)
+        model_path = out_dir / model_file
+        if tex is None or not model_path.exists():
+            continue
+        try:
+            model_obj = json.loads(model_path.read_text(encoding="utf-8"))
+            geometry = model_obj.get("minecraft:geometry", [])
+            if geometry and isinstance(geometry[0], dict):
+                desc = geometry[0].setdefault("description", {})
+                if isinstance(desc, dict):
+                    desc["texture_width"] = tex[0]
+                    desc["texture_height"] = tex[1]
+                    model_path.write_text(json.dumps(model_obj, indent=2), encoding="utf-8")
+        except Exception:
+            pass
+
+    resolved_set: set[str] = set()
+    resolved_assets: list[str] = []
+    for asset_name in manifest["resolved_assets"]:
+        if not isinstance(asset_name, str) or not asset_name or asset_name in resolved_set:
+            continue
+        resolved_set.add(asset_name)
+        resolved_assets.append(asset_name)
+    manifest["resolved_assets"] = resolved_assets
+    unresolved_assets = [
+        asset_name for asset_name in scan.expected_assets
+        if asset_name not in resolved_set
+    ]
+    for asset_name in unresolved_assets:
+        if legacy_asset_category(asset_name)[0] != "animation":
+            continue
+        canonical_name = _canonical_legacy_json_name(asset_name, "animation")
+        if canonical_name is None or (out_dir / canonical_name).exists():
+            continue
+        stub = _build_unresolved_legacy_animation_stub(asset_name)
+        (out_dir / canonical_name).write_text(
+            json.dumps(_strip_private_fields(stub), indent=2),
+            encoding="utf-8",
+        )
+    manifest["unresolved_assets"] = unresolved_assets
+    if codec_format == 1:
+        _enforce_format1_output_shape(out_dir, manifest)
+
+    (out_dir / "legacy_sections.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    if not debug:
+        _prune_legacy_debug_outputs(out_dir)
+    return out_dir
+
+
+def print_legacy_sections(scan: LegacyScanResult) -> None:
+    print(f"file: {scan.path}")
+    print(f"codec_format: {scan.codec_format}")
+    print(f"decoded_len: 0x{scan.decoded_len:x}")
+    print(f"tail_start: 0x{scan.tail_start:x}")
+    print(f"directory_start: 0x{scan.directory_start:x}")
+    print(f"legacy_directory: {len(scan.directory_entries)}")
+    for idx, entry in enumerate(scan.directory_entries[:12]):
+        print(
+            f"dir[{idx}]: control={list(entry.control)} name={entry.name!r} "
+            f"property_match={entry.property_match!r}"
+        )
+    print(f"legacy_sections: {len(scan.sections)}")
+    for idx, sec in enumerate(scan.sections):
+        print(
+            f"section[{idx}]: tag={sec.tag} kind={sec.kind_guess} "
+            f"asset_guess={sec.asset_guess!r} start=0x{sec.start:x} len=0x{sec.size:x}"
+        )
+        if sec.names:
+            print("  names: " + ", ".join(sec.names[:12]))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Heuristic legacy (format 9/15) payload section dumper")
+    ap.add_argument("paths", nargs="+", type=Path)
+    args = ap.parse_args()
+
+    for path in args.paths:
+        scan = scan_legacy_sections(path)
+        print_legacy_sections(scan)
+        out = dump_legacy_sections(path, scan)
+        print(f"{path} -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ysm_extractor/extractors/__init__.py
+++ b/tools/ysm_extractor/extractors/__init__.py
@@ -1,0 +1,1 @@
+"""User-facing extractor package."""

--- a/tools/ysm_extractor/extractors/bom_v3_end_to_end_parser.py
+++ b/tools/ysm_extractor/extractors/bom_v3_end_to_end_parser.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+
+from v3_wrapper_transcode import transcode_wrapper_stream_to_zstd
+from extractors.ysgp_container_scanner import scan_file
+from ysgp_v3_exact_probe import (
+    parse_v3_exact_input,
+    decrypt_v3_reader_exact,
+    _apply_second_stage_variant,
+)
+
+FORMAT_RE = re.compile(r"^\s*<format>\s+(?P<format>\d+)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class BomV3DecodeResult:
+    path: Path
+    codec_format: int | None
+    prelude_skip: int
+    wrapped_offset: int
+    transcoded_zst: bytes
+    decompressed: bytes
+
+
+def _format_family(codec_format: int | None) -> str:
+    if codec_format == 31:
+        return "modern_31"
+    if codec_format in (1, 9, 15):
+        return "legacy_9_15"
+    if codec_format is None:
+        return "unknown"
+    return f"unsupported_{codec_format}"
+
+
+def read_property_format(path: Path) -> int | None:
+    scan = scan_file(path, dump=False)
+    match = FORMAT_RE.search(scan.property_text)
+    if match is None:
+        return None
+    return int(match.group("format"))
+
+
+def _decompress_zstd(buf: bytes) -> bytes:
+    zstd = shutil.which("zstd")
+    if zstd is None:
+        raise RuntimeError("zstd binary not found in PATH")
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(buf)
+        tmp_path = tmp.name
+    try:
+        proc = subprocess.run(
+            [zstd, "-d", "-q", "-c", tmp_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.decode("utf-8", "replace").strip() or "zstd failed")
+        return proc.stdout
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def decode_bom_v3(path: Path) -> BomV3DecodeResult:
+    codec_format = read_property_format(path)
+    exact = parse_v3_exact_input(path)
+    stage1 = decrypt_v3_reader_exact(exact)
+    stage2 = _apply_second_stage_variant(exact.key56, stage1, "mt19937_64_xor")
+    prelude_skip = int.from_bytes(stage2[:2], "little") & 0x3FF
+    wrapped_offset = 2 + prelude_skip
+    wrapped = stage2[wrapped_offset:]
+    transcoded_zst = transcode_wrapper_stream_to_zstd(wrapped)
+    decompressed = _decompress_zstd(transcoded_zst)
+    return BomV3DecodeResult(
+        path=path,
+        codec_format=codec_format,
+        prelude_skip=prelude_skip,
+        wrapped_offset=wrapped_offset,
+        transcoded_zst=transcoded_zst,
+        decompressed=decompressed,
+    )
+
+
+def export_bom_v3_assets(
+    path: Path,
+    codec_format: int | None,
+    *,
+    scan_assets: bool,
+    dump_assets: bool,
+    dump_folder: bool,
+    debug: bool = False,
+) -> Path | None:
+    if codec_format in (1, 9, 15):
+        from bom_v3_legacy_sections import dump_legacy_sections, print_legacy_sections, scan_legacy_sections
+
+        legacy_scan = scan_legacy_sections(path)
+        print_legacy_sections(legacy_scan)
+        if dump_assets or dump_folder:
+            return dump_legacy_sections(path, legacy_scan, debug=debug)
+        return None
+
+    if codec_format == 31:
+        from extractors.bom_v3_payload_assets import _print_result, dump_asset_folder, scan_bom_v3_payload_assets
+
+        asset_result = scan_bom_v3_payload_assets(path)
+        _print_result(asset_result, dump=dump_assets)
+        if dump_folder:
+            return dump_asset_folder(asset_result, debug=debug)
+        return None
+
+    raise RuntimeError(
+        f"unsupported BOM v3 decoded payload format {codec_format!r}; "
+        "currently integrated formats are 1, 9, 15, and 31"
+    )
+
+
+def export_or_restore_bom_v3_assets(
+    path: Path,
+    codec_format: int | None,
+    *,
+    scan_assets: bool,
+    dump_assets: bool,
+    dump_folder: bool,
+    debug: bool = False,
+    source_oracle: Path | None = None,
+    legacy_auto_source_oracle: bool = True,
+) -> tuple[Path | None, Path | None, object | None]:
+    from extractors.bom_v3_source_oracle import (
+        default_export_dir,
+        find_best_source_oracle,
+        restore_from_source_oracle,
+    )
+
+    exported_dir: Path | None = None
+    used_source: Path | None = None
+    oracle = None
+
+    if codec_format == 31 and dump_folder and source_oracle is None:
+        best_source, match_count, asset_count = find_best_source_oracle(path, include_archives=True)
+        exact_auto = best_source is not None and asset_count > 0 and match_count == asset_count
+        if scan_assets or dump_assets or not exact_auto:
+            exported_dir = export_bom_v3_assets(
+                path,
+                codec_format,
+                scan_assets=scan_assets,
+                dump_assets=dump_assets,
+                dump_folder=not exact_auto,
+                debug=debug,
+            )
+        if exact_auto and best_source is not None:
+            used_source = best_source
+            oracle = restore_from_source_oracle(
+                path,
+                best_source,
+                out_dir=default_export_dir(path),
+                clean=True,
+                prefer_source_filenames=True,
+            )
+            exported_dir = oracle.out_dir
+            return exported_dir, used_source, oracle
+        return exported_dir, used_source, oracle
+
+    if scan_assets or dump_assets or dump_folder:
+        exported_dir = export_bom_v3_assets(
+            path,
+            codec_format,
+            scan_assets=scan_assets,
+            dump_assets=dump_assets,
+            dump_folder=dump_folder,
+            debug=debug,
+        )
+
+    if source_oracle is not None:
+        used_source = source_oracle
+        oracle = restore_from_source_oracle(
+            path,
+            source_oracle,
+            out_dir=exported_dir,
+            prefer_source_filenames=(codec_format == 31),
+        )
+        exported_dir = oracle.out_dir
+    elif codec_format in (1, 9, 15) and exported_dir is not None and legacy_auto_source_oracle:
+        best_source, match_count, asset_count = find_best_source_oracle(path)
+        if best_source is not None and match_count > 0:
+            used_source = best_source
+            oracle = restore_from_source_oracle(path, best_source, out_dir=exported_dir)
+            exported_dir = oracle.out_dir
+
+    return exported_dir, used_source, oracle
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="End-to-end BOM+YSGP v3 extractor")
+    ap.add_argument("paths", nargs="+", type=Path)
+    ap.add_argument("--dump-zst", action="store_true")
+    ap.add_argument("--dump-decoded", action="store_true")
+    ap.add_argument("--scan-assets", action="store_true", help="scan decoded payload for property-hash-backed asset sections")
+    ap.add_argument("--dump-assets", action="store_true", help="dump scanned asset sections and exact PNG/JSON payloads")
+    ap.add_argument("--dump-folder", action="store_true", help="export assets into a model-named folder with canonical filenames")
+    ap.add_argument("--debug", action="store_true", help="keep debug artifacts like section bins, manifests, and decompiled stubs")
+    ap.add_argument("--source-oracle", type=Path, help="optional source folder or zip archive for exact hash-based file restore")
+    args = ap.parse_args()
+
+    for path in args.paths:
+        result = decode_bom_v3(path)
+        exported_dir: Path | None = None
+        print(f"file: {path}")
+        print(f"codec_format: {result.codec_format}")
+        print(f"format_family: {_format_family(result.codec_format)}")
+        print(f"prelude_skip: {result.prelude_skip}")
+        print(f"wrapped_offset: 0x{result.wrapped_offset:x}")
+        print(f"transcoded_zst_len: 0x{len(result.transcoded_zst):x}")
+        print(f"decoded_len: 0x{len(result.decompressed):x}")
+        print(f"decoded_head64: {result.decompressed[:64].hex()}")
+        if args.dump_zst:
+            zst_path = path.with_name(f"{path.stem}.transcoded.zst")
+            zst_path.write_bytes(result.transcoded_zst)
+            print(f"dump_zst: {zst_path}")
+        if args.dump_decoded:
+            decoded_path = path.with_name(f"{path.stem}.decoded.bin")
+            decoded_path.write_bytes(result.decompressed)
+            print(f"dump_decoded: {decoded_path}")
+        if args.scan_assets or args.dump_assets or args.dump_folder or args.source_oracle is not None:
+            exported_dir, source_oracle_path, oracle = export_or_restore_bom_v3_assets(
+                path,
+                result.codec_format,
+                scan_assets=args.scan_assets,
+                dump_assets=args.dump_assets,
+                dump_folder=args.dump_folder,
+                debug=args.debug,
+                source_oracle=args.source_oracle,
+            )
+            if exported_dir is not None:
+                print(f"dump_folder: {exported_dir}")
+            if oracle is not None and source_oracle_path is not None:
+                if args.source_oracle is not None:
+                    print(f"source_oracle_restore: {oracle.out_dir}")
+                else:
+                    print(f"source_oracle_auto: {source_oracle_path} ({oracle.match_count}/{oracle.asset_count})")
+                    print(f"source_oracle_restore: {oracle.out_dir}")
+                print(f"source_oracle_match: {oracle.match_count}/{oracle.asset_count}")
+                print(f"exact_restore_complete: {str(oracle.exact_complete).lower()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ysm_extractor/extractors/bom_v3_payload_assets.py
+++ b/tools/ysm_extractor/extractors/bom_v3_payload_assets.py
@@ -1,0 +1,960 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+import math
+import json
+from pathlib import Path
+import re
+import struct
+from typing import Iterable
+
+from extractors.bom_v3_end_to_end_parser import decode_bom_v3
+from extractors.ysgp_container_scanner import scan_file
+
+
+HEX_HASH_RE = re.compile(rb"[0-9a-f]{64}")
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+PROPERTY_NAME_RE = re.compile(r"^\s*<name>\s+(?P<name>.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+PROPERTY_FORMAT_RE = re.compile(r"^\s*<format>\s+(?P<format>\d+)\s*$", re.IGNORECASE | re.MULTILINE)
+COMPILED_ANIM_NAME_EXCLUDES = {
+    "animations",
+    "bones",
+    "format_version",
+    "loop",
+    "position",
+    "rotation",
+    "scale",
+    "timeline",
+    "true",
+    "false",
+    "catmullrom",
+    "hold_on_last_frame",
+    "lerp_mode",
+    "pre",
+    "post",
+    "block",
+    "entity",
+    "player",
+    "default",
+}
+COMPILED_MODEL_NAME_EXCLUDES = {
+    "geometry",
+    "unknown",
+    "default",
+    "bones",
+    "cubes",
+    "pivot",
+    "rotation",
+    "locators",
+    "texturewidth",
+    "textureheight",
+    "format_version",
+    "visible_bounds_width",
+    "visible_bounds_height",
+    "visible_bounds_offset",
+}
+
+
+@dataclass(frozen=True)
+class PropertyAsset:
+    ordinal: int
+    tag: str
+    label: str
+    hash_hex: str
+
+    @property
+    def display_name(self) -> str:
+        if self.label and self.label.lower() != self.tag.lower():
+            return f"{self.tag}_{self.label}"
+        return self.tag
+
+
+@dataclass(frozen=True)
+class AssetRegion:
+    asset: PropertyAsset
+    marker_offset: int
+    region_end: int
+    region_len: int
+    exact_kind: str | None
+    exact_payload_offset: int | None
+    exact_payload_len: int | None
+    exact_payload_sha256: str | None
+    exact_hash_match: bool
+    nearby_strings: tuple[str, ...]
+    name_like_strings: tuple[str, ...]
+    animation_headers: tuple[dict[str, object], ...]
+    raw_section: bytes
+    exact_payload: bytes | None
+
+
+@dataclass(frozen=True)
+class AssetScanResult:
+    path: Path
+    decoded: bytes
+    assets: tuple[AssetRegion, ...]
+
+
+def _sanitize_name(name: str) -> str:
+    out = []
+    for ch in name:
+        if ch.isalnum() or ch in ("-", "_", "."):
+            out.append(ch)
+        else:
+            out.append("_")
+    return "".join(out).strip("_") or "asset"
+
+
+def _read_property_name(path: Path) -> str | None:
+    text = scan_file(path, dump=False).property_text
+    match = PROPERTY_NAME_RE.search(text)
+    if match is None:
+        return None
+    return match.group("name").strip() or None
+
+
+def _read_property_format(path: Path) -> int | None:
+    text = scan_file(path, dump=False).property_text
+    match = PROPERTY_FORMAT_RE.search(text)
+    if match is None:
+        return None
+    return int(match.group("format"))
+
+
+def parse_property_assets(property_text: str) -> list[PropertyAsset]:
+    assets: list[PropertyAsset] = []
+    counts: dict[str, int] = {}
+    for line in property_text.splitlines():
+        stripped = line.strip()
+        if not stripped or not stripped.startswith("<"):
+            continue
+        close = stripped.find(">")
+        if close <= 1:
+            continue
+        tag = stripped[1:close].strip().lower().replace("-", "_")
+        rest = stripped[close + 1:].strip()
+        hash_match = re.search(r"([0-9a-f]{64})$", rest, re.IGNORECASE)
+        if hash_match is None:
+            continue
+        label = rest[:hash_match.start()].strip().lower()
+        label = label.replace(" ", "_")
+        key = f"{tag}:{label}"
+        counts[key] = counts.get(key, 0) + 1
+        if counts[key] > 1:
+            if label:
+                label = f"{label}_{counts[key]}"
+            else:
+                label = str(counts[key])
+        assets.append(
+            PropertyAsset(
+                ordinal=len(assets),
+                tag=tag,
+                label=label,
+                hash_hex=hash_match.group(1).lower(),
+            )
+        )
+    return assets
+
+
+def _extract_ascii_strings(buf: bytes, limit: int = 8) -> tuple[str, ...]:
+    values: list[str] = []
+    for match in re.finditer(rb"[ -~]{4,}", buf):
+        text = match.group().decode("ascii", "replace")
+        if text not in values:
+            values.append(text)
+        if len(values) >= limit:
+            break
+    return tuple(values)
+
+
+def _extract_name_like_strings(buf: bytes, limit: int = 128) -> tuple[str, ...]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for match in re.finditer(rb"[A-Za-z_][A-Za-z0-9_.-]{2,}", buf):
+        text = match.group().decode("ascii", "replace")
+        lower = text.lower()
+        if all(ch in "0123456789abcdef" for ch in lower):
+            continue
+        alpha = sum(ch.isalpha() for ch in text)
+        if alpha < 3:
+            continue
+        if alpha * 2 < len(text):
+            continue
+        if text in seen:
+            continue
+        seen.add(text)
+        values.append(text)
+        if len(values) >= limit:
+            break
+    return tuple(values)
+
+
+def _classify_region_kind(region: AssetRegion) -> str:
+    if region.exact_kind == "png":
+        return "texture_png"
+    name = region.asset.display_name
+    if "animation" in name:
+        return "compiled_animation"
+    if "model" in name or name == "model":
+        return "compiled_model"
+    return "unknown_binary"
+
+
+def _guess_loop_mode(code: int) -> str:
+    mapping = {
+        1: "loop_true",
+        2: "once_or_default",
+        3: "hold_on_last_frame",
+    }
+    return mapping.get(code, f"unknown_{code}")
+
+
+def _canonical_animation_stub_name(file_name: str) -> str:
+    if file_name.endswith(".section.bin"):
+        return file_name[:-12] + ".decompiled.json"
+    return file_name + ".decompiled.json"
+
+
+def _canonical_model_stub_name(file_name: str) -> str:
+    if file_name.endswith(".section.bin"):
+        return file_name[:-12] + ".decompiled.json"
+    return file_name + ".decompiled.json"
+
+
+def _guess_bone_names(names: Iterable[str], clip_names: set[str]) -> list[str]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        lower = name.lower()
+        if name in clip_names:
+            continue
+        if lower in COMPILED_ANIM_NAME_EXCLUDES:
+            continue
+        if lower.startswith("math.") or lower.startswith("query.") or lower.startswith("ysm."):
+            continue
+        if "." in name:
+            continue
+        if len(name) < 3:
+            continue
+        alpha = sum(ch.isalpha() for ch in name)
+        if alpha < 2:
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        values.append(name)
+    return values[:96]
+
+
+def _guess_model_bone_names(names: Iterable[str]) -> list[str]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        lower = name.lower()
+        if lower in COMPILED_MODEL_NAME_EXCLUDES:
+            continue
+        if lower.startswith("math.") or lower.startswith("query.") or lower.startswith("ysm."):
+            continue
+        if len(name) < 3:
+            continue
+        if "." in name and not name.startswith("v."):
+            continue
+        alpha = sum(ch.isalpha() for ch in name)
+        if alpha < 2:
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        values.append(name)
+    return values[:128]
+
+
+def _guess_model_root_names(bone_names: Iterable[str]) -> list[str]:
+    roots: list[str] = []
+    for name in bone_names:
+        lower = name.lower()
+        if lower in {"mroot", "root", "allbody", "upperbody", "upbody", "head"} or lower.endswith("root"):
+            roots.append(name)
+    if not roots:
+        roots = list(bone_names)[:1]
+    return roots[:8]
+
+
+def _guess_model_parent_map(bone_names: list[str]) -> dict[str, str]:
+    parent_map: dict[str, str] = {}
+    lowered = {name.lower(): name for name in bone_names}
+    for name in bone_names:
+        lower = name.lower()
+        if lower.endswith("2") and lower[:-1] in lowered:
+            parent_map[name] = lowered[lower[:-1]]
+        elif lower.startswith("m") and lower[1:] in lowered:
+            parent_map[name] = lowered[lower[1:]]
+        elif lower.startswith("left") and "leftarm" in lowered and lower not in {"leftarm", "leftforearm"}:
+            parent_map.setdefault(name, lowered["leftarm"])
+        elif lower.startswith("right") and "rightarm" in lowered and lower not in {"rightarm", "rightforearm"}:
+            parent_map.setdefault(name, lowered["rightarm"])
+    return parent_map
+
+
+def build_model_decompile_stub(
+    asset_name: str,
+    section_sha256: str,
+    names: Iterable[str],
+) -> dict[str, object]:
+    bone_names = _guess_model_bone_names(names)
+    roots = _guess_model_root_names(bone_names)
+    parent_map = _guess_model_parent_map(bone_names)
+    bones: dict[str, object] = {}
+    for name in bone_names:
+        entry: dict[str, object] = {}
+        if name in roots:
+            entry["__root_guess"] = True
+        parent = parent_map.get(name)
+        if parent is not None:
+            entry["__guessed_parent"] = parent
+        bones[name] = entry
+    return {
+        "__compiled_decompile": {
+            "status": "partial",
+            "asset_name": asset_name,
+            "section_sha256": section_sha256,
+            "bone_count_guess": len(bone_names),
+            "root_count_guess": len(roots),
+            "notes": [
+                "Recovered from compiled YSM model section.",
+                "Bone names are evidence-backed from embedded strings.",
+                "Root and parent links are conservative guesses only.",
+                "Geometry cubes, pivots, rotations, and UVs are not reconstructed yet.",
+            ],
+        },
+        "model": {
+            "bones": bones,
+            "__root_names_guess": roots,
+        },
+    }
+
+
+def _public_geometry_identifier(asset_name: str) -> str:
+    clean = re.sub(r"[^A-Za-z0-9_.-]+", ".", asset_name.strip().lower()).strip(".")
+    return f"geometry.{clean or 'unknown'}"
+
+
+def build_model_public_json(
+    asset_name: str,
+    names: Iterable[str],
+) -> dict[str, object]:
+    bone_names = _guess_model_bone_names(names)
+    parent_map = _guess_model_parent_map(bone_names)
+    roots = set(_guess_model_root_names(bone_names))
+    bones: list[dict[str, object]] = []
+    for name in bone_names:
+        entry: dict[str, object] = {"name": name}
+        parent = parent_map.get(name)
+        if parent is not None and name not in roots:
+            entry["parent"] = parent
+        bones.append(entry)
+    return {
+        "format_version": "1.12.0",
+        "minecraft:geometry": [
+            {
+                "description": {
+                    "identifier": _public_geometry_identifier(asset_name),
+                },
+                "bones": bones,
+            }
+        ],
+    }
+
+
+def build_animation_decompile_stub(
+    asset_name: str,
+    section_sha256: str,
+    names: Iterable[str],
+    animation_headers: Iterable[dict[str, object]],
+) -> dict[str, object]:
+    headers = list(animation_headers)
+    clip_names = {str(h["name"]) for h in headers}
+    bone_names = _guess_bone_names(names, clip_names)
+    animations: dict[str, object] = {}
+    for header in headers:
+        name = str(header["name"])
+        entry: dict[str, object] = {
+            "animation_length": header["seconds_guess"],
+            "__ticks_f32": header["ticks_f32"],
+            "__loop_code": header["loop_code"],
+            "__loop_mode_guess": header["loop_mode_guess"],
+            "__offset": header["offset"],
+            "__bone_names_guess": bone_names,
+            "bones": {},
+        }
+        loop_guess = header["loop_mode_guess"]
+        if loop_guess == "loop_true":
+            entry["loop"] = True
+        elif loop_guess == "hold_on_last_frame":
+            entry["loop"] = "hold_on_last_frame"
+        animations[name] = entry
+    return {
+        "format_version": "1.8.0",
+        "__compiled_decompile": {
+            "status": "partial",
+            "asset_name": asset_name,
+            "section_sha256": section_sha256,
+            "clip_count": len(headers),
+            "bone_name_count_guess": len(bone_names),
+            "notes": [
+                "Recovered from compiled YSM animation section.",
+                "Clip names, durations, and loop modes are evidence-backed.",
+                "Bone lists are guessed from embedded strings.",
+                "Keyframe channels are not reconstructed yet.",
+            ],
+        },
+        "animations": animations,
+    }
+
+
+def build_animation_public_json(
+    animation_headers: Iterable[dict[str, object]],
+) -> dict[str, object]:
+    animations: dict[str, object] = {}
+    for header in animation_headers:
+        name = str(header["name"])
+        entry: dict[str, object] = {
+            "animation_length": header["seconds_guess"],
+            "bones": {},
+        }
+        loop_guess = header["loop_mode_guess"]
+        if loop_guess == "loop_true":
+            entry["loop"] = True
+        elif loop_guess == "hold_on_last_frame":
+            entry["loop"] = "hold_on_last_frame"
+        animations[name] = entry
+    return {
+        "format_version": "1.8.0",
+        "animations": animations,
+    }
+
+
+def _parse_animation_headers(section: bytes) -> tuple[dict[str, object], ...]:
+    headers: list[dict[str, object]] = []
+    seen_offsets: set[int] = set()
+    if len(section) < 74:
+        return tuple()
+
+    for off in range(66, len(section) - 12):
+        name_len = None
+        tag = None
+        if off == 66:
+            name_len = section[65]
+            tag = section[64]
+        elif off >= 4 and section[off - 4:off - 1] == b"\x00\x00\x00":
+            name_len = section[off - 1]
+            tag = 0
+        if name_len is None or name_len < 3 or name_len > 32:
+            continue
+        end = off + name_len
+        if end + 8 > len(section):
+            continue
+        name_bytes = section[off:end]
+        if not re.fullmatch(rb"[A-Za-z_][A-Za-z0-9_.-]{2,31}", name_bytes):
+            continue
+        name = name_bytes.decode("ascii", "replace")
+        ticks = struct.unpack_from("<f", section, end)[0]
+        code = int.from_bytes(section[end + 4:end + 8], "little")
+        if code < 1 or code > 3:
+            continue
+        if not (math.isinf(ticks) or (0.0 <= ticks <= 4096.0)):
+            continue
+        if off in seen_offsets:
+            continue
+        seen_offsets.add(off)
+        headers.append(
+            {
+                "offset": off,
+                "tag_byte": tag,
+                "name_len": name_len,
+                "name": name,
+                "ticks_f32": ticks,
+                "seconds_guess": (ticks / 20.0) if math.isfinite(ticks) else None,
+                "loop_code": code,
+                "loop_mode_guess": _guess_loop_mode(code),
+            }
+        )
+    return tuple(headers)
+
+
+def _parse_png_end(buf: bytes, off: int) -> int | None:
+    if off < 0 or off + 8 > len(buf) or buf[off:off + 8] != PNG_MAGIC:
+        return None
+    pos = off + 8
+    while pos + 12 <= len(buf):
+        chunk_len = int.from_bytes(buf[pos:pos + 4], "big")
+        chunk_type = buf[pos + 4:pos + 8]
+        chunk_end = pos + 12 + chunk_len
+        if chunk_end > len(buf):
+            return None
+        pos = chunk_end
+        if chunk_type == b"IEND":
+            return pos
+    return None
+
+
+def _try_parse_json_at(buf: bytes, off: int) -> bytes | None:
+    if off < 0 or off >= len(buf) or buf[off] != 0x7B:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    for end in range(off, len(buf)):
+        c = buf[end]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == 0x5C:
+                esc = True
+            elif c == 0x22:
+                in_str = False
+            continue
+        if c == 0x22:
+            in_str = True
+        elif c == 0x7B:
+            depth += 1
+        elif c == 0x7D:
+            depth -= 1
+            if depth == 0:
+                blob = buf[off:end + 1]
+                try:
+                    json.loads(blob.decode("utf-8"))
+                except Exception:
+                    return None
+                return blob
+    return None
+
+
+def _find_exact_payload(
+    data: bytes,
+    marker_offset: int,
+    expected_hash: str,
+    next_marker_offset: int,
+) -> tuple[str | None, int | None, bytes | None]:
+    content_probe_start = marker_offset + 64
+    content_probe_end = min(next_marker_offset, marker_offset + 0x2000)
+
+    for start in range(content_probe_start, min(content_probe_start + 0x10, len(data))):
+        end = _parse_png_end(data, start)
+        if end is None:
+            continue
+        payload = data[start:end]
+        if hashlib.sha256(payload).hexdigest() == expected_hash:
+            return ("png", start, payload)
+
+    for start in range(content_probe_start, content_probe_end):
+        if data[start] != 0x7B:
+            continue
+        payload = _try_parse_json_at(data, start)
+        if payload is None:
+            continue
+        if hashlib.sha256(payload).hexdigest() == expected_hash:
+            return ("json", start, payload)
+
+    return (None, None, None)
+
+
+def scan_bom_v3_payload_assets(path: Path) -> AssetScanResult:
+    scan = scan_file(path, dump=False)
+    property_assets = parse_property_assets(scan.property_text)
+    decoded = decode_bom_v3(path).decompressed
+
+    located: list[tuple[int, PropertyAsset]] = []
+    for asset in property_assets:
+        marker = decoded.find(asset.hash_hex.encode("ascii"))
+        if marker < 0:
+            continue
+        located.append((marker, asset))
+    located.sort(key=lambda item: item[0])
+
+    assets: list[AssetRegion] = []
+    for idx, (marker, asset) in enumerate(located):
+        next_marker = len(decoded)
+        if idx + 1 < len(located):
+            next_marker = located[idx + 1][0]
+        kind, payload_off, payload = _find_exact_payload(
+            decoded,
+            marker_offset=marker,
+            expected_hash=asset.hash_hex,
+            next_marker_offset=next_marker,
+        )
+        assets.append(
+            AssetRegion(
+                asset=asset,
+                marker_offset=marker,
+                region_end=next_marker,
+                region_len=next_marker - marker,
+                exact_kind=kind,
+                exact_payload_offset=payload_off,
+                exact_payload_len=len(payload) if payload is not None else None,
+                exact_payload_sha256=hashlib.sha256(payload).hexdigest() if payload is not None else None,
+                exact_hash_match=(payload is not None),
+                nearby_strings=_extract_ascii_strings(decoded[marker: min(next_marker, marker + 0x200)]),
+                name_like_strings=_extract_name_like_strings(decoded[marker:next_marker]),
+                animation_headers=_parse_animation_headers(decoded[marker:next_marker]) if "animation" in asset.display_name else tuple(),
+                raw_section=decoded[marker:next_marker],
+                exact_payload=payload,
+            )
+        )
+
+    return AssetScanResult(
+        path=path,
+        decoded=decoded,
+        assets=tuple(assets),
+    )
+
+
+def dump_asset_regions(result: AssetScanResult) -> list[Path]:
+    outputs: list[Path] = []
+    base = result.path.with_suffix("")
+    bundle_assets: list[dict[str, object]] = []
+    first_marker = min((region.marker_offset for region in result.assets), default=len(result.decoded))
+    for region in result.assets:
+        stem = f"{base.name}.{region.asset.ordinal:02d}.{_sanitize_name(region.asset.display_name)}"
+        raw_path = result.path.with_name(f"{stem}.section.bin")
+        raw_path.write_bytes(region.raw_section)
+        outputs.append(raw_path)
+        manifest = {
+            "source_file": str(result.path),
+            "asset_ordinal": region.asset.ordinal,
+            "asset_tag": region.asset.tag,
+            "asset_label": region.asset.label,
+            "asset_display_name": region.asset.display_name,
+            "asset_hash": region.asset.hash_hex,
+            "marker_offset": region.marker_offset,
+            "region_end": region.region_end,
+            "region_len": region.region_len,
+            "region_kind": _classify_region_kind(region),
+            "exact_kind": region.exact_kind,
+            "exact_payload_offset": region.exact_payload_offset,
+            "exact_payload_len": region.exact_payload_len,
+            "exact_payload_sha256": region.exact_payload_sha256,
+            "exact_hash_match": region.exact_hash_match,
+            "nearby_strings": list(region.nearby_strings),
+            "name_like_strings": list(region.name_like_strings),
+            "animation_headers": list(region.animation_headers),
+        }
+        manifest_path = result.path.with_name(f"{stem}.manifest.json")
+        manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        outputs.append(manifest_path)
+        entry = {
+            "asset_ordinal": region.asset.ordinal,
+            "asset_display_name": region.asset.display_name,
+            "asset_hash": region.asset.hash_hex,
+            "region_kind": _classify_region_kind(region),
+            "marker_offset": region.marker_offset,
+            "region_end": region.region_end,
+            "region_len": region.region_len,
+            "section_file": raw_path.name,
+            "manifest_file": manifest_path.name,
+            "exact_kind": region.exact_kind,
+            "exact_file": None,
+        }
+        if region.exact_payload is not None and region.exact_kind is not None:
+            ext = "png" if region.exact_kind == "png" else "json"
+            exact_path = result.path.with_name(f"{stem}.{ext}")
+            exact_path.write_bytes(region.exact_payload)
+            outputs.append(exact_path)
+            entry["exact_file"] = exact_path.name
+        if region.animation_headers:
+            stub = build_animation_decompile_stub(
+                asset_name=region.asset.display_name,
+                section_sha256=hashlib.sha256(region.raw_section).hexdigest(),
+                names=region.name_like_strings,
+                animation_headers=region.animation_headers,
+            )
+            stub_path = result.path.with_name(f"{stem}.decompiled.json")
+            stub_path.write_text(json.dumps(stub, indent=2), encoding="utf-8")
+            outputs.append(stub_path)
+            entry["decompiled_file"] = stub_path.name
+        elif _classify_region_kind(region) == "compiled_model":
+            stub = build_model_decompile_stub(
+                asset_name=region.asset.display_name,
+                section_sha256=hashlib.sha256(region.raw_section).hexdigest(),
+                names=region.name_like_strings,
+            )
+            stub_path = result.path.with_name(f"{stem}.decompiled.json")
+            stub_path.write_text(json.dumps(stub, indent=2), encoding="utf-8")
+            outputs.append(stub_path)
+            entry["decompiled_file"] = stub_path.name
+        bundle_assets.append(entry)
+    bundle_manifest = {
+        "source_file": str(result.path),
+        "decoded_len": len(result.decoded),
+        "prefix_before_first_marker_hex": result.decoded[:first_marker].hex(),
+        "asset_count": len(bundle_assets),
+        "assets": bundle_assets,
+    }
+    bundle_path = result.path.with_name(f"{base.name}.asset_bundle.json")
+    bundle_path.write_text(json.dumps(bundle_manifest, indent=2), encoding="utf-8")
+    outputs.append(bundle_path)
+    return outputs
+
+
+def _canonical_asset_base(asset: PropertyAsset) -> str:
+    tag = asset.tag.lower()
+    label = _sanitize_name(asset.label.lower()) if asset.label else ""
+    mapping = {
+        "main_model": "main",
+        "model_main": "main",
+        "arm_model": "arm",
+        "model_arm": "arm",
+        "model": "model",
+        "main_animation": "main.animation",
+        "animation_main": "main.animation",
+        "arm_animation": "arm.animation",
+        "extra_animation": "extra.animation",
+        "tac_animation": "tac.animation",
+        "carryon_animation": "carryon.animation",
+    }
+    if tag in mapping:
+        return mapping[tag]
+    if tag.startswith("texture_"):
+        suffix = _sanitize_name(tag[len("texture_"):].replace("_", "."))
+        return f"texture.{suffix}" if suffix else "texture"
+    if tag == "texture":
+        if label and label != "texture":
+            return f"texture.{label}"
+        return "texture"
+    return _sanitize_name(asset.display_name.replace("_", "."))
+
+
+def _canonical_section_filename(region: AssetRegion, used: dict[str, int]) -> str:
+    base = _canonical_asset_base(region.asset)
+    count = used.get(base, 0) + 1
+    used[base] = count
+    if count > 1:
+        base = f"{base}.{count}"
+    if region.exact_kind == "png":
+        return f"{base}.png"
+    if region.exact_kind == "json":
+        return f"{base}.json"
+    kind = _classify_region_kind(region)
+    if kind == "compiled_model":
+        suffix = ".section.bin" if base.endswith(".model") else ".model.section.bin"
+        return f"{base}{suffix}"
+    if kind == "compiled_animation":
+        suffix = ".section.bin" if base.endswith(".animation") else ".animation.section.bin"
+        return f"{base}{suffix}"
+    return f"{base}.section.bin"
+
+
+def _prune_modern_debug_outputs(out_dir: Path) -> None:
+    for pattern in ("*.section.bin", "*.manifest.json", "*.decompiled.json", "asset_bundle.json", "decoded.bin"):
+        for path in out_dir.glob(pattern):
+            path.unlink(missing_ok=True)
+
+
+def _clear_modern_output_dir(out_dir: Path) -> None:
+    for pattern in (
+        "*.json",
+        "*.png",
+        "*.ogg",
+        "*.section.bin",
+        "*.manifest.json",
+        "*.decompiled.json",
+        "property.txt",
+        "decoded.bin",
+        "asset_bundle.json",
+        "oracle_restore.json",
+    ):
+        for path in out_dir.glob(pattern):
+            path.unlink(missing_ok=True)
+
+
+def dump_asset_folder(result: AssetScanResult, *, debug: bool = False) -> Path:
+    folder_name = _sanitize_name(_read_property_name(result.path) or result.path.stem)
+    codec_format = _read_property_format(result.path)
+    out_dir = result.path.with_name(folder_name)
+    if out_dir.exists() and codec_format is not None:
+        out_dir = result.path.with_name(f"{folder_name}_format{codec_format}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    _clear_modern_output_dir(out_dir)
+
+    scan = scan_file(result.path, dump=False)
+    (out_dir / "property.txt").write_text(scan.property_text, encoding="utf-8")
+    if debug:
+        (out_dir / "decoded.bin").write_bytes(result.decoded)
+
+    used: dict[str, int] = {}
+    bundle_assets: list[dict[str, object]] = []
+    first_marker = min((region.marker_offset for region in result.assets), default=len(result.decoded))
+
+    for region in result.assets:
+        file_name = _canonical_section_filename(region, used)
+        kind = _classify_region_kind(region)
+        asset_path: Path | None = None
+        decompiled_name: str | None = None
+
+        if region.exact_payload is not None and region.exact_kind is not None:
+            asset_path = out_dir / file_name
+            asset_path.write_bytes(region.exact_payload)
+        elif kind == "compiled_model":
+            public_name = file_name.replace(".model.section.bin", ".json").replace(".section.bin", ".json")
+            asset_path = out_dir / public_name
+            public_model = build_model_public_json(
+                asset_name=region.asset.display_name,
+                names=region.name_like_strings,
+            )
+            asset_path.write_text(json.dumps(public_model, indent=2), encoding="utf-8")
+            if debug:
+                debug_stub = build_model_decompile_stub(
+                    asset_name=region.asset.display_name,
+                    section_sha256=hashlib.sha256(region.raw_section).hexdigest(),
+                    names=region.name_like_strings,
+                )
+                decompiled_name = _canonical_model_stub_name(file_name)
+                (out_dir / decompiled_name).write_text(json.dumps(debug_stub, indent=2), encoding="utf-8")
+        elif kind == "compiled_animation":
+            if file_name.endswith(".animation.section.bin"):
+                public_name = file_name[:-len(".animation.section.bin")] + ".animation.json"
+            else:
+                public_name = file_name.replace(".section.bin", ".json")
+            asset_path = out_dir / public_name
+            public_anim = build_animation_public_json(region.animation_headers)
+            asset_path.write_text(json.dumps(public_anim, indent=2), encoding="utf-8")
+            if debug:
+                debug_stub = build_animation_decompile_stub(
+                    asset_name=region.asset.display_name,
+                    section_sha256=hashlib.sha256(region.raw_section).hexdigest(),
+                    names=region.name_like_strings,
+                    animation_headers=region.animation_headers,
+                )
+                decompiled_name = _canonical_animation_stub_name(file_name)
+                (out_dir / decompiled_name).write_text(json.dumps(debug_stub, indent=2), encoding="utf-8")
+        elif debug:
+            asset_path = out_dir / file_name
+            asset_path.write_bytes(region.raw_section)
+
+        if asset_path is None:
+            continue
+
+        manifest = {
+            "source_file": str(result.path),
+            "asset_ordinal": region.asset.ordinal,
+            "asset_tag": region.asset.tag,
+            "asset_label": region.asset.label,
+            "asset_display_name": region.asset.display_name,
+            "asset_hash": region.asset.hash_hex,
+            "region_kind": _classify_region_kind(region),
+            "marker_offset": region.marker_offset,
+            "region_end": region.region_end,
+            "region_len": region.region_len,
+            "exact_kind": region.exact_kind,
+            "exact_payload_offset": region.exact_payload_offset,
+            "exact_payload_len": region.exact_payload_len,
+            "exact_payload_sha256": region.exact_payload_sha256,
+            "exact_hash_match": region.exact_hash_match,
+            "nearby_strings": list(region.nearby_strings),
+            "name_like_strings": list(region.name_like_strings),
+            "animation_headers": list(region.animation_headers),
+            "export_file": asset_path.name,
+        }
+        manifest_name: str | None = None
+        if debug:
+            manifest_name = f"{asset_path.name}.manifest.json"
+            (out_dir / manifest_name).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        bundle_assets.append(
+            {
+                "asset_ordinal": region.asset.ordinal,
+                "asset_display_name": region.asset.display_name,
+                "asset_hash": region.asset.hash_hex,
+                "region_kind": _classify_region_kind(region),
+                "export_file": asset_path.name,
+                "manifest_file": manifest_name,
+                "exact_kind": region.exact_kind,
+                "decompiled_file": decompiled_name,
+            }
+        )
+
+    bundle_manifest = {
+        "source_file": str(result.path),
+        "decoded_len": len(result.decoded),
+        "prefix_before_first_marker_hex": result.decoded[:first_marker].hex(),
+        "asset_count": len(bundle_assets),
+        "assets": bundle_assets,
+    }
+    if debug:
+        (out_dir / "asset_bundle.json").write_text(json.dumps(bundle_manifest, indent=2), encoding="utf-8")
+    if not debug:
+        _prune_modern_debug_outputs(out_dir)
+    return out_dir
+
+
+def _print_result(result: AssetScanResult, dump: bool) -> None:
+    print(f"file: {result.path}")
+    print(f"decoded_len: 0x{len(result.decoded):x}")
+    print(f"property_hash_sections: {len(result.assets)}")
+    dumped: set[Path] = set()
+    if dump:
+        dumped = set(dump_asset_regions(result))
+    for region in result.assets:
+        label = region.asset.display_name
+        print(
+            f"asset[{region.asset.ordinal}]: name={label!r} hash={region.asset.hash_hex} "
+            f"marker=0x{region.marker_offset:x} region_len=0x{region.region_len:x}"
+        )
+        if region.exact_kind is None:
+            print("  exact_payload: none")
+        else:
+            print(
+                f"  exact_payload: kind={region.exact_kind} off=0x{region.exact_payload_offset:x} "
+                f"len=0x{region.exact_payload_len:x} sha256_match={region.exact_hash_match}"
+            )
+        if region.nearby_strings:
+            print("  strings: " + " | ".join(region.nearby_strings[:6]))
+        if region.name_like_strings:
+            preview = ", ".join(region.name_like_strings[:12])
+            print(f"  names: {preview}")
+        if region.animation_headers:
+            for header in region.animation_headers[:8]:
+                sec = header["seconds_guess"]
+                sec_text = f"{sec:.5f}" if isinstance(sec, float) else "None"
+                print(
+                    "  anim: "
+                    f"{header['name']} ticks={header['ticks_f32']!r} seconds={sec_text} "
+                    f"loop_code={header['loop_code']} loop_guess={header['loop_mode_guess']}"
+                )
+        if dump:
+            bundle_path = result.path.with_name(f"{result.path.with_suffix('').name}.asset_bundle.json")
+            raw_path = result.path.with_name(
+                f"{result.path.with_suffix('').name}.{region.asset.ordinal:02d}.{_sanitize_name(label)}.section.bin"
+            )
+            manifest_path = result.path.with_name(
+                f"{result.path.with_suffix('').name}.{region.asset.ordinal:02d}.{_sanitize_name(label)}.manifest.json"
+            )
+            if region.asset.ordinal == 0:
+                print(f"bundle_manifest: {bundle_path}")
+            print(f"  dump_section: {raw_path}")
+            print(f"  dump_manifest: {manifest_path}")
+            if region.exact_payload is not None and region.exact_kind is not None:
+                exact_ext = "png" if region.exact_kind == "png" else "json"
+                exact_path = result.path.with_name(
+                    f"{result.path.with_suffix('').name}.{region.asset.ordinal:02d}.{_sanitize_name(label)}.{exact_ext}"
+                )
+                print(f"  dump_exact: {exact_path}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Scan decompressed BOM v3 payload for property-hash-backed asset sections")
+    ap.add_argument("paths", nargs="+", type=Path)
+    ap.add_argument("--dump", action="store_true", help="dump raw hash-bounded sections and exact PNG/JSON payloads")
+    ap.add_argument("--dump-folder", action="store_true", help="export into a model-named folder with canonical filenames")
+    args = ap.parse_args()
+
+    for path in args.paths:
+        result = scan_bom_v3_payload_assets(path)
+        _print_result(result, dump=args.dump)
+        if args.dump_folder:
+            out_dir = dump_asset_folder(result)
+            print(f"dump_folder: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ysm_extractor/extractors/bom_v3_source_oracle.py
+++ b/tools/ysm_extractor/extractors/bom_v3_source_oracle.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from extractors.bom_v3_payload_assets import _read_property_format, _read_property_name, _sanitize_name, parse_property_assets
+from extractors.ysgp_container_scanner import scan_file
+
+
+@dataclass(frozen=True)
+class OracleMatch:
+    tag: str
+    label: str
+    hash_hex: str
+    source_relpath: str | None
+    export_name: str
+
+
+@dataclass(frozen=True)
+class OracleSourceEntry:
+    source_relpath: str
+    data: bytes
+
+
+@dataclass(frozen=True)
+class OracleRestoreSummary:
+    out_dir: Path
+    match_count: int
+    asset_count: int
+
+    @property
+    def exact_complete(self) -> bool:
+        return self.asset_count > 0 and self.match_count == self.asset_count
+
+
+def _iter_source_entries(source_root: Path) -> Iterable[OracleSourceEntry]:
+    if source_root.is_dir():
+        for path in source_root.rglob("*"):
+            if not path.is_file():
+                continue
+            yield OracleSourceEntry(str(path.relative_to(source_root)).replace("\\", "/"), path.read_bytes())
+        return
+    if source_root.is_file() and zipfile.is_zipfile(source_root):
+        with zipfile.ZipFile(source_root) as zf:
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                yield OracleSourceEntry(info.filename.replace("\\", "/"), zf.read(info))
+        return
+    raise ValueError(f"unsupported source oracle candidate: {source_root}")
+
+
+def _build_hash_to_entry(source_root: Path) -> dict[str, OracleSourceEntry]:
+    hash_to_entry: dict[str, OracleSourceEntry] = {}
+    for entry in _iter_source_entries(source_root):
+        hash_to_entry[hashlib.sha256(entry.data).hexdigest()] = entry
+    return hash_to_entry
+
+
+def _is_source_tree_candidate(path: Path) -> bool:
+    try:
+        if not path.is_dir():
+            return False
+    except (OSError, PermissionError):
+        return False
+    if path.name.startswith("."):
+        return False
+    try:
+        if (path / "oracle_restore.json").exists():
+            return False
+        if (path / "legacy_sections.json").exists():
+            return False
+    except (OSError, PermissionError):
+        return False
+    markers = (
+        path / "models",
+        path / "animations",
+        path / "textures",
+        path / "sounds",
+        path / "avatar",
+        path / "ysm.json",
+    )
+    try:
+        return any(marker.exists() for marker in markers)
+    except (OSError, PermissionError):
+        return False
+
+
+def _is_source_archive_candidate(path: Path) -> bool:
+    try:
+        return path.is_file() and path.suffix.lower() == ".zip" and zipfile.is_zipfile(path)
+    except (OSError, PermissionError, zipfile.BadZipFile):
+        return False
+
+
+def default_export_dir(ysm_path: Path) -> Path:
+    folder_name = _sanitize_name(_read_property_name(ysm_path) or ysm_path.stem)
+    codec_format = _read_property_format(ysm_path)
+    out_dir = ysm_path.with_name(folder_name)
+    if out_dir.exists() and codec_format is not None:
+        out_dir = ysm_path.with_name(f"{folder_name}_format{codec_format}")
+    return out_dir
+
+
+def find_best_source_oracle(
+    ysm_path: Path,
+    search_roots: Iterable[Path] | None = None,
+    *,
+    include_archives: bool = False,
+) -> tuple[Path | None, int, int]:
+    assets = parse_property_assets(scan_file(ysm_path, dump=False).property_text)
+    wanted = {asset.hash_hex for asset in assets}
+    if not wanted:
+        return (None, 0, 0)
+
+    if search_roots is None:
+        roots = [ysm_path.parent]
+    else:
+        roots = list(search_roots)
+
+    candidates: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        try:
+            children = list(root.iterdir())
+        except (OSError, PermissionError):
+            continue
+        for child in children:
+            if _is_source_tree_candidate(child):
+                candidates.append(child)
+            elif include_archives and _is_source_archive_candidate(child):
+                candidates.append(child)
+
+    best_dir: Path | None = None
+    best_count = 0
+    total = len(wanted)
+    for candidate in candidates:
+        hash_to_entry = _build_hash_to_entry(candidate)
+        count = sum(1 for digest in wanted if digest in hash_to_entry)
+        if count > best_count:
+            best_dir = candidate
+            best_count = count
+            if best_count == total:
+                break
+    return (best_dir, best_count, total)
+
+
+def _canonical_name(tag: str, label: str, source_path: Path | None) -> str:
+    tag = tag.lower()
+    label = label.lower()
+    ext = source_path.suffix if source_path is not None else ""
+    if tag in ("main_model", "model_main"):
+        return "main.json"
+    if tag in ("arm_model", "model_arm"):
+        return "arm.json"
+    if tag in ("arrow_model",):
+        return "arrow.json"
+    if tag == "model":
+        return f"model{ext or '.bin'}"
+    if tag in ("main_animation", "animation_main"):
+        return "main.animation.json"
+    if tag == "arm_animation":
+        return "arm.animation.json"
+    if tag == "extra_animation":
+        return "extra.animation.json"
+    if tag == "tac_animation":
+        return "tac.animation.json"
+    if tag == "carryon_animation":
+        return "carryon.animation.json"
+    if tag == "arrow_animation":
+        return "arrow.animation.json"
+    if tag.startswith("texture_"):
+        return f"{tag[len('texture_'):]}{ext or '.bin'}"
+    if tag == "arrow_texture":
+        return f"arrow{ext or '.bin'}"
+    if tag == "texture":
+        name = label or "texture"
+        return f"{name}{ext or '.bin'}"
+    if tag.endswith((".png", ".jpg", ".jpeg", ".tga")):
+        return f"texture{ext or Path(tag).suffix or '.bin'}"
+    if tag.startswith("sound_"):
+        return f"{tag[len('sound_'):]}{ext or '.bin'}"
+    base = tag if not label else f"{tag}_{label}"
+    return f"{base}{ext or '.bin'}"
+
+
+def _source_basename(entry: OracleSourceEntry) -> str:
+    name = Path(entry.source_relpath).name
+    return name or _sanitize_name(entry.source_relpath.replace("/", "_"))
+
+
+def _clear_output_dir(out_dir: Path) -> None:
+    for pattern in (
+        "*.json",
+        "*.png",
+        "*.ogg",
+        "*.bin",
+        "*.section.bin",
+        "*.manifest.json",
+        "*.decompiled.json",
+        "property.txt",
+        "decoded.bin",
+        "asset_bundle.json",
+        "oracle_restore.json",
+    ):
+        for path in out_dir.glob(pattern):
+            path.unlink(missing_ok=True)
+
+
+def restore_from_source_oracle(
+    ysm_path: Path,
+    source_root: Path,
+    out_dir: Path | None = None,
+    *,
+    clean: bool = False,
+    prefer_source_filenames: bool = False,
+) -> OracleRestoreSummary:
+    assets = parse_property_assets(scan_file(ysm_path, dump=False).property_text)
+    hash_to_entry = _build_hash_to_entry(source_root)
+
+    if out_dir is None:
+        out_dir = ysm_path.with_name(
+            f"{_sanitize_name(_read_property_name(ysm_path) or ysm_path.stem)}_oracle_restore_format"
+            f"{_read_property_format(ysm_path) or 'unknown'}"
+        )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if clean:
+        _clear_output_dir(out_dir)
+    old_manifest = out_dir / "oracle_restore.json"
+    if old_manifest.exists():
+        try:
+            old_obj = json.loads(old_manifest.read_text(encoding="utf-8"))
+            for entry in old_obj.get("assets", []):
+                export_name = entry.get("export_name")
+                if isinstance(export_name, str):
+                    (out_dir / export_name).unlink(missing_ok=True)
+        except Exception:
+            pass
+
+    property_text = scan_file(ysm_path, dump=False).property_text
+    (out_dir / "property.txt").write_text(property_text, encoding="utf-8")
+
+    matches: list[OracleMatch] = []
+    matched_tags: set[str] = set()
+    exported_names: set[str] = set()
+    used_names: dict[str, int] = {}
+    for asset in assets:
+        src = hash_to_entry.get(asset.hash_hex)
+        if prefer_source_filenames and src is not None:
+            export_name = _source_basename(src)
+        else:
+            export_name = _canonical_name(asset.tag, asset.label, Path(src.source_relpath) if src is not None else None)
+        count = used_names.get(export_name, 0) + 1
+        used_names[export_name] = count
+        if count > 1:
+            stem = Path(export_name).stem
+            suffix = Path(export_name).suffix
+            export_name = f"{stem}.{count}{suffix}"
+        matches.append(
+            OracleMatch(
+                tag=asset.tag,
+                label=asset.label,
+                hash_hex=asset.hash_hex,
+                source_relpath=src.source_relpath if src is not None else None,
+                export_name=export_name,
+            )
+        )
+        if src is not None:
+            matched_tags.add(asset.tag.lower())
+            (out_dir / export_name).write_bytes(src.data)
+            exported_names.add(export_name)
+
+    if any(tag.startswith("texture") or tag == "arrow_texture" for tag in matched_tags):
+        for stale_name in ("texture.png", "texture.2.png"):
+            if stale_name not in exported_names:
+                (out_dir / stale_name).unlink(missing_ok=True)
+    if any(tag.startswith("sound_") for tag in matched_tags):
+        for stale in out_dir.glob("legacy.*.audio.ogg"):
+            if stale.name not in exported_names:
+                stale.unlink(missing_ok=True)
+
+    codec_format = _read_property_format(ysm_path)
+    manifest = {
+        "source_file": str(ysm_path),
+        "source_root": str(source_root),
+        "codec_format": codec_format,
+        "match_count": sum(1 for m in matches if m.source_relpath is not None),
+        "asset_count": len(matches),
+        "exact_restore_complete": sum(1 for m in matches if m.source_relpath is not None) == len(matches) and len(matches) > 0,
+        "assets": [m.__dict__ for m in matches],
+    }
+    (out_dir / "oracle_restore.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return OracleRestoreSummary(
+        out_dir=out_dir,
+        match_count=manifest["match_count"],
+        asset_count=manifest["asset_count"],
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Restore exact source files from a YSM property-hash oracle")
+    ap.add_argument("ysm_path", type=Path)
+    ap.add_argument("source_root", type=Path)
+    args = ap.parse_args()
+    out = restore_from_source_oracle(args.ysm_path, args.source_root)
+    print(out.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ysm_extractor/extractors/legacy_asset_inventory.py
+++ b/tools/ysm_extractor/extractors/legacy_asset_inventory.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from extractors.bom_v3_payload_assets import PropertyAsset, _sanitize_name
+
+
+IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".tga")
+MODEL_TAGS = {
+    "main_model": "main.json",
+    "arm_model": "arm.json",
+    "arrow_model": "arrow.json",
+}
+
+
+@dataclass(frozen=True)
+class LegacyDeclaredExportInventory:
+    model_files: tuple[str, ...]
+    animation_files: tuple[str, ...]
+    texture_files: tuple[str, ...]
+    sound_files: tuple[str, ...]
+
+
+def canonical_legacy_export_name(tag: str, label: str, codec_format: int | None = None) -> str:
+    del codec_format
+    tag = str(tag).lower()
+    label = _sanitize_name(str(label).strip().lower())
+    if tag in MODEL_TAGS:
+        return MODEL_TAGS[tag]
+    if tag.endswith("_animation"):
+        stem = _sanitize_name(tag[: -len("_animation")] or label or "animation")
+        return f"{stem.replace('_', '.')}.animation.json"
+    if tag == "arrow_texture":
+        return "arrow.png"
+    if tag == "texture":
+        return f"{label or 'texture'}.png"
+    if tag.startswith("texture_"):
+        stem = _sanitize_name(tag[len("texture_") :] or label or "texture")
+        return f"{stem}.png"
+    if tag.endswith(IMAGE_SUFFIXES):
+        suffix = "".join(ch for ch in tag if ch in "._/" or ch.isalnum())
+        stem = _sanitize_name(label or tag.rsplit(".", 1)[0] or "texture")
+        ext = "." + suffix.rsplit(".", 1)[-1] if "." in suffix else ".png"
+        return f"{stem}{ext}"
+    if tag == "sound":
+        return f"{label or 'sound'}.ogg"
+    if tag.startswith("sound_"):
+        stem = _sanitize_name(tag[len("sound_") :] or label or "sound")
+        return f"{stem}.ogg"
+    safe_tag = _sanitize_name(tag)
+    if label:
+        return f"{safe_tag}_{label}.bin"
+    return f"{safe_tag}.bin"
+
+
+def legacy_asset_category(tag: str) -> tuple[str, str]:
+    tag = str(tag).lower()
+    if tag in MODEL_TAGS:
+        return ("model", tag.replace("_model", ""))
+    if tag.endswith("_animation"):
+        return ("animation", tag[: -len("_animation")] or "animation")
+    if tag == "arrow_texture":
+        return ("texture", "arrow")
+    if tag == "texture" or tag.startswith("texture_") or tag.endswith(IMAGE_SUFFIXES):
+        return ("texture", "main")
+    if tag == "sound" or tag.startswith("sound_"):
+        return ("sound", "sound")
+    return ("binary", "other")
+
+
+def build_legacy_declared_export_inventory(
+    assets: tuple[PropertyAsset, ...] | list[PropertyAsset],
+    codec_format: int | None = None,
+) -> LegacyDeclaredExportInventory:
+    categories: dict[str, list[str]] = {
+        "model": [],
+        "animation": [],
+        "texture": [],
+        "sound": [],
+    }
+    seen: dict[str, set[str]] = {key: set() for key in categories}
+    for asset in assets:
+        category, _family = legacy_asset_category(asset.tag)
+        if category not in categories:
+            continue
+        export_name = canonical_legacy_export_name(asset.tag, asset.label, codec_format)
+        if export_name in seen[category]:
+            continue
+        seen[category].add(export_name)
+        categories[category].append(export_name)
+    return LegacyDeclaredExportInventory(
+        model_files=tuple(categories["model"]),
+        animation_files=tuple(categories["animation"]),
+        texture_files=tuple(categories["texture"]),
+        sound_files=tuple(categories["sound"]),
+    )

--- a/tools/ysm_extractor/extractors/verify_format15_equivalence.py
+++ b/tools/ysm_extractor/extractors/verify_format15_equivalence.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from extractors.bom_v3_source_oracle import find_best_source_oracle
+from extractors.verify_legacy_pair import _compare_export_tree, verify_legacy_pair
+from extractors.ysm_legacy_native_lift import parse_legacy_native_state
+
+
+def verify_format15_equivalence(
+    ysm_path: Path,
+    source_root: Path | None,
+    *,
+    top_bones: int = 10,
+    asset_scope: str = "full",
+) -> int:
+    ysm_path = ysm_path.resolve()
+    state = parse_legacy_native_state(ysm_path)
+    if state.codec_format != 15:
+        raise SystemExit(f"expected format 15, got {state.codec_format!r}")
+
+    if source_root is None:
+        best_root, match_count, asset_count = find_best_source_oracle(ysm_path, include_archives=True)
+        if best_root is not None and match_count > 0:
+            source_root = best_root
+            print(f"auto_source_root: {source_root} ({match_count}/{asset_count})")
+
+    heuristic_report = verify_legacy_pair(
+        ysm_path,
+        source_root,
+        backend="heuristic",
+        expected_format=15,
+        top_bones=top_bones,
+        asset_scope=asset_scope,
+    )
+    native_report = verify_legacy_pair(
+        ysm_path,
+        source_root,
+        backend="native_lift",
+        expected_format=15,
+        top_bones=top_bones,
+        asset_scope=asset_scope,
+    )
+    heuristic_vs_native = _compare_export_tree(
+        heuristic_report.dump_folder,
+        native_report.dump_folder,
+        state=state,
+        top_bones=top_bones,
+        asset_scope=asset_scope,
+    )
+
+    print(f"file: {ysm_path}")
+    print("codec_format: 15")
+    print(f"source_root: {source_root if source_root is not None else '-'}")
+    print(f"heuristic_dump_folder: {heuristic_report.dump_folder}")
+    print(f"native_lift_dump_folder: {native_report.dump_folder}")
+    print(f"heuristic_vs_native_models_equal: {str(heuristic_vs_native.models_equal).lower()}")
+    print(f"heuristic_vs_native_animations_equal: {str(heuristic_vs_native.animations_equal).lower()}")
+    print(f"heuristic_vs_native_textures_equal: {str(heuristic_vs_native.textures_equal).lower()}")
+    print(f"heuristic_vs_native_sounds_equal: {str(heuristic_vs_native.sounds_equal).lower()}")
+    print(f"heuristic_vs_native_overall_equivalent: {str(heuristic_vs_native.overall_equivalent).lower()}")
+    for item in heuristic_vs_native.mismatches:
+        print(f"heuristic_vs_native_mismatch: {item}")
+    for item in heuristic_vs_native.details:
+        print(f"heuristic_vs_native_detail: {item}")
+
+    if heuristic_report.source_report is not None:
+        report = heuristic_report.source_report
+        print(f"heuristic_vs_oracle_models_equal: {str(report.models_equal).lower()}")
+        print(f"heuristic_vs_oracle_animations_equal: {str(report.animations_equal).lower()}")
+        print(f"heuristic_vs_oracle_textures_equal: {str(report.textures_equal).lower()}")
+        print(f"heuristic_vs_oracle_sounds_equal: {str(report.sounds_equal).lower()}")
+        print(f"heuristic_vs_oracle_overall_equivalent: {str(report.overall_equivalent).lower()}")
+        for item in report.mismatches:
+            print(f"heuristic_vs_oracle_mismatch: {item}")
+        for item in report.details:
+            print(f"heuristic_vs_oracle_detail: {item}")
+    if native_report.source_report is not None:
+        report = native_report.source_report
+        print(f"native_lift_vs_oracle_models_equal: {str(report.models_equal).lower()}")
+        print(f"native_lift_vs_oracle_animations_equal: {str(report.animations_equal).lower()}")
+        print(f"native_lift_vs_oracle_textures_equal: {str(report.textures_equal).lower()}")
+        print(f"native_lift_vs_oracle_sounds_equal: {str(report.sounds_equal).lower()}")
+        print(f"native_lift_vs_oracle_overall_equivalent: {str(report.overall_equivalent).lower()}")
+        for item in report.mismatches:
+            print(f"native_lift_vs_oracle_mismatch: {item}")
+        for item in report.details:
+            print(f"native_lift_vs_oracle_detail: {item}")
+
+    ok = heuristic_vs_native.overall_equivalent
+    if source_root is not None:
+        ok = ok and bool(heuristic_report.source_report and heuristic_report.source_report.overall_equivalent)
+        ok = ok and bool(native_report.source_report and native_report.source_report.overall_equivalent)
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Verify format-15 heuristic and source-less native_lift exports against each other and a nearby folder/zip oracle when available."
+    )
+    ap.add_argument("ysm_path", type=Path)
+    ap.add_argument("--source-root", type=Path, help="optional paired source tree or zip archive")
+    ap.add_argument(
+        "--asset-scope",
+        choices=("full", "models", "animations"),
+        default="full",
+        help="compare the full declared export set, only model JSONs, or only animation JSONs",
+    )
+    ap.add_argument("--top-bones", type=int, default=10, help="number of top per-bone deltas to print")
+    args = ap.parse_args()
+    return verify_format15_equivalence(
+        args.ysm_path,
+        args.source_root,
+        top_bones=args.top_bones,
+        asset_scope=args.asset_scope,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/extractors/verify_format1_equivalence.py
+++ b/tools/ysm_extractor/extractors/verify_format1_equivalence.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import io
+import json
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from bom_v3_legacy_sections import dump_legacy_sections
+from extractors.verify_legacy_pair import _describe_model_diff, _json_equal, _load_json
+from extractors.ysm_legacy_native_lift import export_legacy_native_lift
+from extractors.bom_v3_end_to_end_parser import decode_bom_v3
+
+
+FORMAT1_MODEL_FILES = ("main.json", "arm.json")
+FORMAT1_ANIMATION_FILES = (
+    "main.animation.json",
+    "arm.animation.json",
+    "extra.animation.json",
+    "tac.animation.json",
+    "carryon.animation.json",
+)
+FORBIDDEN_FORMAT1_FILES = ("arrow.json", "arrow.animation.json")
+
+
+@dataclass(frozen=True)
+class Format1Comparison:
+    models_equal: bool
+    animations_equal: bool
+    textures_equal: bool
+    sounds_equal: bool
+    asset_hashes_equal: bool
+    model_metadata_hashes_equal: bool
+    shape_ok: bool
+    hash_mismatches: tuple[str, ...]
+    metadata_mismatches: tuple[str, ...]
+    shape_issues: tuple[str, ...]
+    details: tuple[str, ...]
+
+    @property
+    def overall_equivalent(self) -> bool:
+        return (
+            self.models_equal
+            and self.animations_equal
+            and self.textures_equal
+            and self.sounds_equal
+            and self.asset_hashes_equal
+            and self.model_metadata_hashes_equal
+            and self.shape_ok
+        )
+
+
+def _round_num(value: Any) -> Any:
+    if isinstance(value, float):
+        return round(value, 5)
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _metadata_hash(path: Path) -> tuple[str, dict[str, Any]]:
+    obj = _load_json(path)
+    geometry = obj.get("minecraft:geometry", [])
+    geom = geometry[0] if isinstance(geometry, list) and geometry and isinstance(geometry[0], dict) else {}
+    desc = geom.get("description", {}) if isinstance(geom, dict) else {}
+    bones = []
+    raw_bones = geom.get("bones", []) if isinstance(geom, dict) else []
+    if isinstance(raw_bones, list):
+        for bone in raw_bones:
+            if not isinstance(bone, dict):
+                continue
+            bones.append(
+                {
+                    "name": bone.get("name"),
+                    "parent": bone.get("parent"),
+                    "pivot": _round_num(bone.get("pivot")),
+                    "rotation": _round_num(bone.get("rotation")),
+                    "cube_count": len(bone.get("cubes", [])) if isinstance(bone.get("cubes"), list) else 0,
+                }
+            )
+    bones.sort(key=lambda item: str(item.get("name", "")))
+    payload = {
+        "identifier": desc.get("identifier") if isinstance(desc, dict) else None,
+        "texture_width": desc.get("texture_width") if isinstance(desc, dict) else None,
+        "texture_height": desc.get("texture_height") if isinstance(desc, dict) else None,
+        "bone_count": len(bones),
+        "cube_total": sum(int(item["cube_count"]) for item in bones),
+        "bones": bones,
+    }
+    blob = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest(), payload
+
+
+def _layout_roots(root: Path) -> tuple[Path, Path, Path, Path]:
+    model_root = root / "models"
+    animation_root = root / "animations"
+    texture_root = root / "textures"
+    sound_root = root / "sounds"
+    if any(path.is_dir() for path in (model_root, animation_root, texture_root, sound_root)):
+        return (
+            model_root if model_root.is_dir() else root,
+            animation_root if animation_root.is_dir() else root,
+            texture_root if texture_root.is_dir() else root,
+            sound_root if sound_root.is_dir() else root,
+        )
+    return root, root, root, root
+
+
+def _collect_format1_assets(root: Path) -> tuple[dict[str, Path], list[Path], list[Path]]:
+    model_root, animation_root, texture_root, sound_root = _layout_roots(root)
+    assets: dict[str, Path] = {}
+    for name in FORMAT1_MODEL_FILES:
+        path = model_root / name
+        if path.is_file():
+            assets[name] = path
+    for name in FORMAT1_ANIMATION_FILES:
+        path = animation_root / name
+        if path.is_file():
+            assets[name] = path
+    pngs = sorted(path for path in texture_root.glob("*.png") if path.is_file())
+    if len(pngs) == 1:
+        assets[pngs[0].name] = pngs[0]
+    oggs = sorted(path for path in sound_root.glob("*.ogg") if path.is_file())
+    return assets, pngs, oggs
+
+
+def _asset_hashes(root: Path) -> dict[str, str]:
+    assets, _pngs, _oggs = _collect_format1_assets(root)
+    return {name: _sha256_file(path) for name, path in sorted(assets.items())}
+
+
+def _model_metadata_hashes(root: Path) -> dict[str, str]:
+    model_root, _animation_root, _texture_root, _sound_root = _layout_roots(root)
+    hashes: dict[str, str] = {}
+    for name in FORMAT1_MODEL_FILES:
+        path = model_root / name
+        if not path.is_file():
+            continue
+        hashes[name] = _metadata_hash(path)[0]
+    return hashes
+
+
+def _shape_issues(root: Path) -> list[str]:
+    issues: list[str] = []
+    model_root, animation_root, texture_root, sound_root = _layout_roots(root)
+    for name in FORMAT1_MODEL_FILES:
+        if not (model_root / name).is_file():
+            issues.append(f"missing required model: {name}")
+    for name in FORMAT1_ANIMATION_FILES:
+        if not (animation_root / name).is_file():
+            issues.append(f"missing required animation: {name}")
+    for name in FORBIDDEN_FORMAT1_FILES:
+        forbidden = model_root / name if name.endswith(".json") and not name.endswith(".animation.json") else animation_root / name
+        if forbidden.is_file():
+            issues.append(f"forbidden format1 export present: {name}")
+    pngs = sorted(path for path in texture_root.glob("*.png") if path.is_file())
+    if len(pngs) != 1:
+        issues.append(f"expected exactly one texture png, found {len(pngs)}")
+    oggs = sorted(path for path in sound_root.glob("*.ogg") if path.is_file())
+    if oggs:
+        issues.append(f"forbidden sound exports present: {', '.join(path.name for path in oggs)}")
+    return issues
+
+
+def _compare_model_group(left_root: Path, right_root: Path, *, top_bones: int) -> tuple[bool, list[str]]:
+    model_left_root, _animation_left_root, _texture_left_root, _sound_left_root = _layout_roots(left_root)
+    model_right_root, _animation_right_root, _texture_right_root, _sound_right_root = _layout_roots(right_root)
+    equal = True
+    details: list[str] = []
+    for name in FORMAT1_MODEL_FILES:
+        left = model_left_root / name
+        right = model_right_root / name
+        if _json_equal(left, right, model=True):
+            continue
+        equal = False
+        details.extend(_describe_model_diff(left, right, name, name, top_bones=top_bones))
+    return equal, details
+
+
+def _compare_animation_group(left_root: Path, right_root: Path) -> bool:
+    _model_left_root, animation_left_root, _texture_left_root, _sound_left_root = _layout_roots(left_root)
+    _model_right_root, animation_right_root, _texture_right_root, _sound_right_root = _layout_roots(right_root)
+    return all(
+        _json_equal(animation_left_root / name, animation_right_root / name, model=False)
+        for name in FORMAT1_ANIMATION_FILES
+    )
+
+
+def _compare_hash_sets(
+    left_hashes: dict[str, str],
+    right_hashes: dict[str, str],
+) -> tuple[bool, list[str]]:
+    mismatches: list[str] = []
+    for name in sorted(set(left_hashes) | set(right_hashes)):
+        if left_hashes.get(name) != right_hashes.get(name):
+            mismatches.append(name)
+    return not mismatches, mismatches
+
+
+def _compare_metadata_sets(
+    left_hashes: dict[str, str],
+    right_hashes: dict[str, str],
+) -> tuple[bool, list[str]]:
+    mismatches: list[str] = []
+    for name in FORMAT1_MODEL_FILES:
+        if left_hashes.get(name) != right_hashes.get(name):
+            mismatches.append(name)
+    return not mismatches, mismatches
+
+
+def _compare_format1_exports(left_root: Path, right_root: Path, *, top_bones: int) -> Format1Comparison:
+    left_assets, left_pngs, left_oggs = _collect_format1_assets(left_root)
+    right_assets, right_pngs, right_oggs = _collect_format1_assets(right_root)
+    left_asset_hashes = {name: _sha256_file(path) for name, path in sorted(left_assets.items())}
+    right_asset_hashes = {name: _sha256_file(path) for name, path in sorted(right_assets.items())}
+    left_metadata = _model_metadata_hashes(left_root)
+    right_metadata = _model_metadata_hashes(right_root)
+
+    models_equal, details = _compare_model_group(left_root, right_root, top_bones=top_bones)
+    animations_equal = _compare_animation_group(left_root, right_root)
+    textures_equal = len(left_pngs) == len(right_pngs) == 1 and left_asset_hashes.get(left_pngs[0].name) == right_asset_hashes.get(right_pngs[0].name)
+    sounds_equal = not left_oggs and not right_oggs
+    asset_hashes_equal, hash_mismatches = _compare_hash_sets(left_asset_hashes, right_asset_hashes)
+    model_metadata_hashes_equal, metadata_mismatches = _compare_metadata_sets(left_metadata, right_metadata)
+    shape_issues = _shape_issues(left_root) + [f"reference: {item}" for item in _shape_issues(right_root)]
+
+    return Format1Comparison(
+        models_equal=models_equal,
+        animations_equal=animations_equal,
+        textures_equal=textures_equal,
+        sounds_equal=sounds_equal,
+        asset_hashes_equal=asset_hashes_equal,
+        model_metadata_hashes_equal=model_metadata_hashes_equal,
+        shape_ok=not shape_issues,
+        hash_mismatches=tuple(hash_mismatches),
+        metadata_mismatches=tuple(metadata_mismatches),
+        shape_issues=tuple(shape_issues),
+        details=tuple(details),
+    )
+
+
+def verify_format1_against_snapshot(
+    ysm_path: Path,
+    *,
+    official_export_root: Path,
+    top_bones: int = 10,
+) -> int:
+    ysm_path = ysm_path.resolve()
+    official_export_root = official_export_root.resolve()
+    codec_format = decode_bom_v3(ysm_path).codec_format
+    if codec_format != 1:
+        raise SystemExit(f"expected format 1, got {codec_format!r}")
+    with tempfile.TemporaryDirectory(prefix="format1_heur_", dir="/tmp") as heur_tmp, tempfile.TemporaryDirectory(
+        prefix="format1_native_", dir="/tmp"
+    ) as native_tmp:
+        heur_dir = Path(heur_tmp)
+        native_dir = Path(native_tmp)
+        with contextlib.redirect_stdout(io.StringIO()):
+            dump_legacy_sections(ysm_path, out_dir=heur_dir, debug=False)
+            export_legacy_native_lift(ysm_path, out_dir=native_dir)
+
+        heuristic_vs_official = _compare_format1_exports(heur_dir, official_export_root, top_bones=top_bones)
+        native_vs_official = _compare_format1_exports(native_dir, official_export_root, top_bones=top_bones)
+        heuristic_vs_native = _compare_format1_exports(heur_dir, native_dir, top_bones=top_bones)
+
+        print(f"file: {ysm_path}")
+        print("codec_format: 1")
+        print(f"official_export_root: {official_export_root}")
+        print(f"heuristic_dump_folder: {heur_dir}")
+        print(f"native_lift_dump_folder: {native_dir}")
+
+        for label, root in (
+            ("official", official_export_root),
+            ("heuristic", heur_dir),
+            ("native_lift", native_dir),
+        ):
+            for name, digest in sorted(_asset_hashes(root).items()):
+                print(f"{label}_asset_hash: {name} {digest}")
+            for name, digest in sorted(_model_metadata_hashes(root).items()):
+                print(f"{label}_model_metadata_hash: {name} {digest}")
+
+        print(f"heuristic_models_equal: {str(heuristic_vs_official.models_equal).lower()}")
+        print(f"heuristic_animations_equal: {str(heuristic_vs_official.animations_equal).lower()}")
+        print(f"heuristic_textures_equal: {str(heuristic_vs_official.textures_equal).lower()}")
+        print(f"heuristic_sounds_equal: {str(heuristic_vs_official.sounds_equal).lower()}")
+        print(f"heuristic_asset_hashes_equal: {str(heuristic_vs_official.asset_hashes_equal).lower()}")
+        print(
+            f"heuristic_model_metadata_hashes_equal: "
+            f"{str(heuristic_vs_official.model_metadata_hashes_equal).lower()}"
+        )
+        print(f"heuristic_shape_ok: {str(heuristic_vs_official.shape_ok).lower()}")
+        print(f"heuristic_overall_equivalent: {str(heuristic_vs_official.overall_equivalent).lower()}")
+
+        print(f"native_lift_models_equal: {str(native_vs_official.models_equal).lower()}")
+        print(f"native_lift_animations_equal: {str(native_vs_official.animations_equal).lower()}")
+        print(f"native_lift_textures_equal: {str(native_vs_official.textures_equal).lower()}")
+        print(f"native_lift_sounds_equal: {str(native_vs_official.sounds_equal).lower()}")
+        print(f"native_lift_asset_hashes_equal: {str(native_vs_official.asset_hashes_equal).lower()}")
+        print(
+            f"native_lift_model_metadata_hashes_equal: "
+            f"{str(native_vs_official.model_metadata_hashes_equal).lower()}"
+        )
+        print(f"native_lift_shape_ok: {str(native_vs_official.shape_ok).lower()}")
+        print(f"native_lift_overall_equivalent: {str(native_vs_official.overall_equivalent).lower()}")
+
+        print(
+            f"heuristic_vs_native_asset_hashes_equal: "
+            f"{str(heuristic_vs_native.asset_hashes_equal).lower()}"
+        )
+        print(
+            f"heuristic_vs_native_model_metadata_hashes_equal: "
+            f"{str(heuristic_vs_native.model_metadata_hashes_equal).lower()}"
+        )
+        print(f"heuristic_vs_native_shape_ok: {str(heuristic_vs_native.shape_ok).lower()}")
+
+        for label, report in (
+            ("heuristic", heuristic_vs_official),
+            ("native_lift", native_vs_official),
+            ("heuristic_vs_native", heuristic_vs_native),
+        ):
+            for name in report.hash_mismatches:
+                print(f"{label}_hash_mismatch: {name}")
+            for name in report.metadata_mismatches:
+                print(f"{label}_metadata_hash_mismatch: {name}")
+            for item in report.shape_issues:
+                print(f"{label}_shape_issue: {item}")
+            for item in report.details:
+                print(f"{label}_detail: {item}")
+
+        ok = (
+            heuristic_vs_official.overall_equivalent
+            and native_vs_official.overall_equivalent
+            and heuristic_vs_native.asset_hashes_equal
+            and heuristic_vs_native.model_metadata_hashes_equal
+            and heuristic_vs_native.shape_ok
+        )
+        return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Verify format-1 heuristic and source-less native_lift exports against an official snapshot."
+    )
+    ap.add_argument("ysm_path", type=Path)
+    ap.add_argument(
+        "--official-export-root",
+        type=Path,
+        required=True,
+        help="canonical format-1 official export snapshot or raw export root",
+    )
+    ap.add_argument("--top-bones", type=int, default=10, help="number of top per-bone deltas to print")
+    args = ap.parse_args()
+    return verify_format1_against_snapshot(
+        args.ysm_path,
+        official_export_root=args.official_export_root,
+        top_bones=args.top_bones,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/extractors/verify_format9_equivalence.py
+++ b/tools/ysm_extractor/extractors/verify_format9_equivalence.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import io
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from bom_v3_legacy_sections import dump_legacy_sections
+from extractors.verify_legacy_pair import (
+    _compare_export_tree,
+    _load_json,
+    _print_report,
+    verify_legacy_pair,
+)
+from extractors.ysm_legacy_native_lift import export_legacy_native_lift, parse_legacy_native_state
+
+
+def _expected_asset_map(root: Path, state) -> dict[str, Path]:
+    assets: dict[str, Path] = {}
+    from extractors.verify_legacy_pair import _resolve_expected_export_file
+
+    for name in state.expected_model_files:
+        path = _resolve_expected_export_file(root, name, kind="model")
+        if path is not None:
+            assets[name] = path
+    for name in state.expected_animation_files:
+        path = _resolve_expected_export_file(root, name, kind="animation")
+        if path is not None:
+            assets[name] = path
+    for name in state.expected_texture_files:
+        path = _resolve_expected_export_file(root, name, kind="texture")
+        if path is not None:
+            assets[name] = path
+    for name in state.expected_sound_files:
+        path = _resolve_expected_export_file(root, name, kind="sound")
+        if path is not None:
+            assets[name] = path
+    return assets
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _round_num(value: Any) -> Any:
+    if isinstance(value, float):
+        return round(value, 5)
+    return value
+
+
+def _metadata_hash(path: Path) -> tuple[str, dict[str, Any]]:
+    obj = _load_json(path)
+    geometry = obj.get("minecraft:geometry", [])
+    geom = geometry[0] if isinstance(geometry, list) and geometry and isinstance(geometry[0], dict) else {}
+    desc = geom.get("description", {}) if isinstance(geom, dict) else {}
+    bones = []
+    raw_bones = geom.get("bones", []) if isinstance(geom, dict) else []
+    if isinstance(raw_bones, list):
+        for bone in raw_bones:
+            if not isinstance(bone, dict):
+                continue
+            bones.append(
+                {
+                    "name": bone.get("name"),
+                    "parent": bone.get("parent"),
+                    "pivot": _round_num(bone.get("pivot")),
+                    "rotation": _round_num(bone.get("rotation")),
+                    "cube_count": len(bone.get("cubes", [])) if isinstance(bone.get("cubes"), list) else 0,
+                }
+            )
+    bones.sort(key=lambda item: str(item.get("name", "")))
+    payload = {
+        "identifier": desc.get("identifier") if isinstance(desc, dict) else None,
+        "texture_width": desc.get("texture_width") if isinstance(desc, dict) else None,
+        "texture_height": desc.get("texture_height") if isinstance(desc, dict) else None,
+        "bone_count": len(bones),
+        "cube_total": sum(int(item["cube_count"]) for item in bones),
+        "bones": bones,
+    }
+    blob = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest(), payload
+
+
+def verify_format9_against_native_lift(ysm_path: Path, *, top_bones: int = 10) -> int:
+    ysm_path = ysm_path.resolve()
+    state = parse_legacy_native_state(ysm_path)
+    with tempfile.TemporaryDirectory(prefix="format9_heur_", dir="/tmp") as heur_tmp, tempfile.TemporaryDirectory(
+        prefix="format9_native_", dir="/tmp"
+    ) as native_tmp:
+        heur_dir = Path(heur_tmp)
+        native_dir = Path(native_tmp)
+        with contextlib.redirect_stdout(io.StringIO()):
+            dump_legacy_sections(ysm_path, out_dir=heur_dir, debug=False)
+            export_legacy_native_lift(ysm_path, out_dir=native_dir)
+
+        report = _compare_export_tree(heur_dir, native_dir, state=state, top_bones=top_bones)
+        heur_assets = _expected_asset_map(heur_dir, state)
+        native_assets = _expected_asset_map(native_dir, state)
+        all_asset_names = sorted(set(heur_assets) | set(native_assets))
+        hash_mismatches: list[str] = []
+        for relpath in all_asset_names:
+            heur_path = heur_assets.get(relpath)
+            native_path = native_assets.get(relpath)
+            if heur_path is None or native_path is None:
+                hash_mismatches.append(relpath)
+                continue
+            if _sha256_file(heur_path) != _sha256_file(native_path):
+                hash_mismatches.append(relpath)
+
+        metadata_mismatches: list[str] = []
+        for model_name in ("main.json", "arm.json", "arrow.json"):
+            heur_path = heur_dir / model_name
+            native_path = native_dir / model_name
+            if not heur_path.exists() and not native_path.exists():
+                continue
+            if not heur_path.exists() or not native_path.exists():
+                metadata_mismatches.append(model_name)
+                continue
+            heur_hash, heur_meta = _metadata_hash(heur_path)
+            native_hash, native_meta = _metadata_hash(native_path)
+            if heur_hash != native_hash:
+                metadata_mismatches.append(model_name)
+                print(f"metadata_mismatch: {model_name}")
+                print(
+                    f"metadata_detail: {model_name}: "
+                    f"heur_bones={heur_meta['bone_count']} native_bones={native_meta['bone_count']} "
+                    f"heur_cubes={heur_meta['cube_total']} native_cubes={native_meta['cube_total']}"
+                )
+
+        print(f"file: {ysm_path}")
+        print("codec_format: 9")
+        print(f"heuristic_dump_folder: {heur_dir}")
+        print(f"native_lift_dump_folder: {native_dir}")
+        print(f"models_equal: {str(report.models_equal).lower()}")
+        print(f"animations_equal: {str(report.animations_equal).lower()}")
+        print(f"textures_equal: {str(report.textures_equal).lower()}")
+        print(f"sounds_equal: {str(report.sounds_equal).lower()}")
+        print(f"overall_equivalent: {str(report.overall_equivalent).lower()}")
+        print(f"asset_hashes_equal: {str(not hash_mismatches).lower()}")
+        print(f"model_metadata_hashes_equal: {str(not metadata_mismatches).lower()}")
+        for relpath in hash_mismatches:
+            print(f"hash_mismatch: {relpath}")
+        for relpath in metadata_mismatches:
+            print(f"metadata_hash_mismatch: {relpath}")
+        for item in report.mismatches:
+            print(f"mismatch: {item}")
+        for item in report.details:
+            print(f"detail: {item}")
+        return 0 if report.overall_equivalent and not hash_mismatches and not metadata_mismatches else 1
+
+
+def verify_format9(ysm_path: Path, source_root: Path | None) -> int:
+    report = verify_legacy_pair(ysm_path, source_root, expected_format=9)
+    _print_report(report, show_official=True, official_jar=None)
+    return 0 if report.overall_equivalent else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Verify oracle-free format 9 extraction against a paired source tree."
+    )
+    ap.add_argument("ysm_path", type=Path)
+    ap.add_argument(
+        "--source-root",
+        type=Path,
+        help="paired source tree; if omitted, auto-discover the best nearby source-oracle candidate",
+    )
+    ap.add_argument(
+        "--compare-native-lift",
+        action="store_true",
+        help="compare fresh format-9 heuristic output against fresh native_lift output instead of a source tree",
+    )
+    ap.add_argument("--top-bones", type=int, default=10, help="number of top per-bone deltas to print")
+    args = ap.parse_args()
+    if args.compare_native_lift:
+        return verify_format9_against_native_lift(args.ysm_path, top_bones=args.top_bones)
+    return verify_format9(args.ysm_path, args.source_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/extractors/verify_legacy_pair.py
+++ b/tools/ysm_extractor/extractors/verify_legacy_pair.py
@@ -1,0 +1,739 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from bom_v3_legacy_sections import _png_pixels_equal
+from extractors.bom_v3_end_to_end_parser import decode_bom_v3, export_bom_v3_assets
+from extractors.bom_v3_source_oracle import find_best_source_oracle
+from extractors.ysm_legacy_native_lift import export_legacy_native_lift, parse_legacy_native_state
+from extractors.ysm262_official import probe_ysm262_official
+
+SOUND_GLOB = "*.ogg"
+
+
+@dataclass(frozen=True)
+class BoneSummary:
+    cube_count: int
+    pivot: tuple[float, float, float] | None
+
+
+@dataclass(frozen=True)
+class ComparisonReport:
+    root: Path
+    models_equal: bool
+    animations_equal: bool
+    textures_equal: bool
+    sounds_equal: bool
+    mismatches: tuple[str, ...]
+    details: tuple[str, ...]
+
+    @property
+    def overall_equivalent(self) -> bool:
+        return self.models_equal and self.animations_equal and self.textures_equal and self.sounds_equal
+
+
+@dataclass(frozen=True)
+class VerificationReport:
+    ysm_path: Path
+    codec_format: int
+    backend: str
+    dump_folder: Path
+    source_root: Path | None
+    source_report: ComparisonReport | None = None
+    official_report: ComparisonReport | None = None
+    official_vs_source_report: ComparisonReport | None = None
+
+    @property
+    def primary_report(self) -> ComparisonReport:
+        if self.source_report is not None:
+            return self.source_report
+        if self.official_report is not None:
+            return self.official_report
+        raise RuntimeError("verification report has no comparisons")
+
+    @property
+    def models_equal(self) -> bool:
+        return self.primary_report.models_equal
+
+    @property
+    def animations_equal(self) -> bool:
+        return self.primary_report.animations_equal
+
+    @property
+    def textures_equal(self) -> bool:
+        return self.primary_report.textures_equal
+
+    @property
+    def sounds_equal(self) -> bool:
+        return self.primary_report.sounds_equal
+
+    @property
+    def mismatches(self) -> tuple[str, ...]:
+        return self.primary_report.mismatches
+
+    @property
+    def details(self) -> tuple[str, ...]:
+        return self.primary_report.details
+
+    @property
+    def overall_equivalent(self) -> bool:
+        return self.primary_report.overall_equivalent
+
+
+def _round_num(value: Any) -> Any:
+    if isinstance(value, float):
+        return round(value, 5)
+    return value
+
+
+def _canon_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _canon_json(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_canon_json(item) for item in value]
+    return _round_num(value)
+
+
+def _canon_model_json(obj: dict[str, Any]) -> dict[str, Any]:
+    canon = _canon_json(obj)
+    geometry = canon.get("minecraft:geometry")
+    if not isinstance(geometry, list):
+        return canon
+    normalized_geometry: list[dict[str, Any]] = []
+    for geom in geometry:
+        if not isinstance(geom, dict):
+            normalized_geometry.append(geom)
+            continue
+        bones = geom.get("bones")
+        if isinstance(bones, list):
+            geom = dict(geom)
+            geom["bones"] = sorted(
+                [bone for bone in bones if isinstance(bone, dict)],
+                key=lambda bone: str(bone.get("name", "")),
+            )
+        normalized_geometry.append(geom)
+    canon["minecraft:geometry"] = normalized_geometry
+    return canon
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _json_equal(extracted: Path | None, source: Path | None, *, model: bool) -> bool:
+    if extracted is None or source is None:
+        return extracted is source
+    if not extracted.exists() or not source.exists():
+        return extracted.exists() == source.exists()
+    out_obj = _load_json(extracted)
+    src_obj = _load_json(source)
+    if model:
+        return _canon_model_json(out_obj) == _canon_model_json(src_obj)
+    return _canon_json(out_obj) == _canon_json(src_obj)
+
+
+def _find_geometry_bones(obj: Any) -> list[dict[str, Any]]:
+    if not isinstance(obj, dict):
+        return []
+    geometry = obj.get("minecraft:geometry")
+    if not isinstance(geometry, list):
+        return []
+    for geom in geometry:
+        if not isinstance(geom, dict):
+            continue
+        bones = geom.get("bones")
+        if isinstance(bones, list):
+            return [bone for bone in bones if isinstance(bone, dict)]
+    return []
+
+
+def _model_bone_summary(path: Path) -> dict[str, BoneSummary]:
+    bones = _find_geometry_bones(_load_json(path))
+    out: dict[str, BoneSummary] = {}
+    for bone in bones:
+        name = bone.get("name")
+        if not isinstance(name, str):
+            continue
+        cubes = bone.get("cubes")
+        pivot = bone.get("pivot")
+        pivot_tuple: tuple[float, float, float] | None = None
+        if isinstance(pivot, list) and len(pivot) == 3:
+            try:
+                pivot_tuple = tuple(float(v) for v in pivot)
+            except Exception:
+                pivot_tuple = None
+        out[name] = BoneSummary(
+            cube_count=len(cubes) if isinstance(cubes, list) else 0,
+            pivot=pivot_tuple,
+        )
+    return out
+
+
+def _cube_total(summary: dict[str, BoneSummary]) -> int:
+    return sum(item.cube_count for item in summary.values())
+
+
+def _format_name_list(names: list[str], *, limit: int = 8) -> str:
+    if not names:
+        return "-"
+    clipped = names[:limit]
+    suffix = "" if len(names) <= limit else f" (+{len(names) - limit} more)"
+    return ", ".join(clipped) + suffix
+
+
+def _pivot_delta(a: tuple[float, float, float] | None, b: tuple[float, float, float] | None) -> float:
+    if a is None or b is None:
+        return 0.0
+    return round(sum(abs(x - y) for x, y in zip(a, b)), 5)
+
+
+def _describe_model_diff(extracted: Path, source: Path, out_name: str, src_rel: str, *, top_bones: int) -> list[str]:
+    details: list[str] = []
+    if not extracted.exists() or not source.exists():
+        details.append(
+            f"{out_name}: missing file extracted={extracted.exists()} source={source.exists()} ({src_rel})"
+        )
+        return details
+
+    out_summary = _model_bone_summary(extracted)
+    src_summary = _model_bone_summary(source)
+    missing = sorted(set(src_summary) - set(out_summary))
+    extra = sorted(set(out_summary) - set(src_summary))
+    details.append(
+        f"{out_name}: bones extracted={len(out_summary)} source={len(src_summary)}; "
+        f"cubes extracted={_cube_total(out_summary)} source={_cube_total(src_summary)}"
+    )
+    if missing:
+        details.append(f"{out_name}: missing bones: {_format_name_list(missing)}")
+    if extra:
+        details.append(f"{out_name}: extra bones: {_format_name_list(extra)}")
+
+    cube_deltas: list[tuple[int, str, int, int]] = []
+    pivot_deltas: list[tuple[float, str, tuple[float, float, float] | None, tuple[float, float, float] | None]] = []
+    for name in sorted(set(out_summary) & set(src_summary)):
+        out_item = out_summary[name]
+        src_item = src_summary[name]
+        if out_item.cube_count != src_item.cube_count:
+            cube_deltas.append(
+                (abs(out_item.cube_count - src_item.cube_count), name, out_item.cube_count, src_item.cube_count)
+            )
+        delta = _pivot_delta(out_item.pivot, src_item.pivot)
+        if delta > 0.01:
+            pivot_deltas.append((delta, name, out_item.pivot, src_item.pivot))
+
+    cube_deltas.sort(key=lambda item: (-item[0], item[1]))
+    pivot_deltas.sort(key=lambda item: (-item[0], item[1]))
+    if cube_deltas:
+        rendered = ", ".join(
+            f"{name}({out_count}->{src_count})"
+            for _, name, out_count, src_count in cube_deltas[:top_bones]
+        )
+        details.append(f"{out_name}: top cube deltas: {rendered}")
+    if pivot_deltas:
+        rendered = ", ".join(
+            f"{name}(L1={delta:.3f})"
+            for delta, name, _, _ in pivot_deltas[:top_bones]
+        )
+        details.append(f"{out_name}: top pivot deltas: {rendered}")
+    return details
+
+
+def _animation_clip_summary(path: Path) -> dict[str, dict[str, Any]]:
+    obj = _load_json(path)
+    animations = obj.get("animations")
+    if not isinstance(animations, dict):
+        return {}
+    summary: dict[str, dict[str, Any]] = {}
+    for clip_name, clip in animations.items():
+        if not isinstance(clip_name, str) or not isinstance(clip, dict):
+            continue
+        bones = clip.get("bones")
+        bone_map = bones if isinstance(bones, dict) else {}
+        channel_count = 0
+        keyframe_count = 0
+        for bone_value in bone_map.values():
+            if not isinstance(bone_value, dict):
+                continue
+            channel_count += len(bone_value)
+            for channel_value in bone_value.values():
+                if isinstance(channel_value, list):
+                    keyframe_count += len(channel_value)
+                elif channel_value is not None:
+                    keyframe_count += 1
+        summary[clip_name] = {
+            "loop": clip.get("loop"),
+            "length": clip.get("animation_length", clip.get("length")),
+            "bones": sorted(name for name in bone_map if isinstance(name, str)),
+            "channel_count": channel_count,
+            "keyframe_count": keyframe_count,
+        }
+    return summary
+
+
+def _describe_animation_diff(extracted: Path, source: Path, out_name: str, *, top_clips: int) -> list[str]:
+    details: list[str] = []
+    if not extracted.exists() or not source.exists():
+        details.append(
+            f"{out_name}: missing file extracted={extracted.exists()} source={source.exists()}"
+        )
+        return details
+
+    out_summary = _animation_clip_summary(extracted)
+    src_summary = _animation_clip_summary(source)
+    missing = sorted(set(src_summary) - set(out_summary))
+    extra = sorted(set(out_summary) - set(src_summary))
+    details.append(
+        f"{out_name}: clips extracted={len(out_summary)} source={len(src_summary)}"
+    )
+    if missing:
+        details.append(f"{out_name}: missing clips: {_format_name_list(missing, limit=top_clips)}")
+    if extra:
+        details.append(f"{out_name}: extra clips: {_format_name_list(extra, limit=top_clips)}")
+
+    loop_mismatches: list[str] = []
+    length_mismatches: list[str] = []
+    bone_mismatches: list[tuple[int, str, int, int]] = []
+    channel_mismatches: list[tuple[int, str, int, int, int, int]] = []
+    for name in sorted(set(out_summary) & set(src_summary)):
+        out_item = out_summary[name]
+        src_item = src_summary[name]
+        if out_item["loop"] != src_item["loop"]:
+            loop_mismatches.append(name)
+        if out_item["length"] != src_item["length"]:
+            length_mismatches.append(name)
+        out_bones = set(out_item["bones"])
+        src_bones = set(src_item["bones"])
+        if out_bones != src_bones:
+            bone_mismatches.append((abs(len(out_bones) - len(src_bones)), name, len(out_bones), len(src_bones)))
+        if (
+            out_item["channel_count"] != src_item["channel_count"]
+            or out_item["keyframe_count"] != src_item["keyframe_count"]
+        ):
+            channel_mismatches.append(
+                (
+                    abs(int(out_item["keyframe_count"]) - int(src_item["keyframe_count"])),
+                    name,
+                    int(out_item["channel_count"]),
+                    int(src_item["channel_count"]),
+                    int(out_item["keyframe_count"]),
+                    int(src_item["keyframe_count"]),
+                )
+            )
+    if loop_mismatches:
+        details.append(f"{out_name}: loop mismatches: {_format_name_list(loop_mismatches, limit=top_clips)}")
+    if length_mismatches:
+        details.append(f"{out_name}: duration mismatches: {_format_name_list(length_mismatches, limit=top_clips)}")
+    if bone_mismatches:
+        bone_mismatches.sort(key=lambda item: (-item[0], item[1]))
+        rendered = ", ".join(
+            f"{name}({out_bones}->{src_bones})"
+            for _, name, out_bones, src_bones in bone_mismatches[:top_clips]
+        )
+        details.append(f"{out_name}: top bone-count deltas: {rendered}")
+    if channel_mismatches:
+        channel_mismatches.sort(key=lambda item: (-item[0], item[1]))
+        rendered = ", ".join(
+            f"{name}(channels {out_channels}->{src_channels}, keys {out_keys}->{src_keys})"
+            for _, name, out_channels, src_channels, out_keys, src_keys in channel_mismatches[:top_clips]
+        )
+        details.append(f"{out_name}: top channel/key deltas: {rendered}")
+    return details
+
+
+def _resolve_expected_export_file(root: Path, file_name: str, *, kind: str) -> Path | None:
+    subdir = {
+        "model": "models",
+        "animation": "animations",
+        "texture": "textures",
+        "sound": "sounds",
+    }.get(kind, "")
+    candidates = [root / file_name]
+    if subdir:
+        candidates.append(root / subdir / file_name)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    matches = sorted(path for path in root.rglob(file_name) if path.is_file())
+    if len(matches) == 1:
+        return matches[0]
+    return matches[0] if matches else None
+
+
+def _verify_json_group(
+    left_root: Path,
+    right_root: Path,
+    file_names: tuple[str, ...],
+    *,
+    kind: str,
+    model: bool,
+    top_bones: int,
+) -> tuple[list[str], list[str]]:
+    mismatches: list[str] = []
+    details: list[str] = []
+    for file_name in file_names:
+        out_path = _resolve_expected_export_file(left_root, file_name, kind=kind)
+        src_path = _resolve_expected_export_file(right_root, file_name, kind=kind)
+        if _json_equal(out_path, src_path, model=model):
+            continue
+        mismatches.append(file_name)
+        if model:
+            details.extend(
+                _describe_model_diff(
+                    out_path or (left_root / file_name),
+                    src_path or (right_root / file_name),
+                    file_name,
+                    file_name,
+                    top_bones=top_bones,
+                )
+            )
+        elif kind == "animation":
+            details.extend(
+                _describe_animation_diff(
+                    out_path or (left_root / file_name),
+                    src_path or (right_root / file_name),
+                    file_name,
+                    top_clips=top_bones,
+                )
+            )
+        else:
+            details.append(
+                f"{file_name}: missing file extracted={bool(out_path and out_path.exists())} "
+                f"source={bool(src_path and src_path.exists())}"
+            )
+    return mismatches, details
+
+
+def _verify_textures(
+    left_root: Path,
+    right_root: Path,
+    file_names: tuple[str, ...],
+) -> tuple[list[str], list[str]]:
+    mismatches: list[str] = []
+    details: list[str] = []
+    for file_name in file_names:
+        out_path = _resolve_expected_export_file(left_root, file_name, kind="texture")
+        src_path = _resolve_expected_export_file(right_root, file_name, kind="texture")
+        if out_path is None or src_path is None:
+            mismatches.append(file_name)
+            details.append(
+                f"{file_name}: missing texture extracted={out_path is not None} source={src_path is not None}"
+            )
+            continue
+        if not _png_pixels_equal(out_path.read_bytes(), src_path.read_bytes()):
+            mismatches.append(file_name)
+            details.append(f"{file_name}: texture pixels differ")
+    return mismatches, details
+
+
+def _verify_sounds(
+    left_root: Path,
+    right_root: Path,
+    file_names: tuple[str, ...],
+) -> tuple[list[str], list[str]]:
+    mismatches: list[str] = []
+    details: list[str] = []
+    for file_name in file_names:
+        out_path = _resolve_expected_export_file(left_root, file_name, kind="sound")
+        src_path = _resolve_expected_export_file(right_root, file_name, kind="sound")
+        if out_path is None or src_path is None:
+            mismatches.append(file_name)
+            details.append(
+                f"{file_name}: missing sound extracted={out_path is not None} source={src_path is not None}"
+            )
+            continue
+        if out_path.read_bytes() != src_path.read_bytes():
+            mismatches.append(file_name)
+            details.append(f"{file_name}: sound bytes differ")
+    return mismatches, details
+
+
+def _compare_export_tree(
+    left_root: Path,
+    right_root: Path,
+    *,
+    state,
+    top_bones: int,
+    asset_scope: str = "full",
+) -> ComparisonReport:
+    if asset_scope == "animations":
+        model_mismatches = []
+        model_details = []
+    else:
+        model_mismatches, model_details = _verify_json_group(
+            left_root,
+            right_root,
+            state.expected_model_files,
+            kind="model",
+            model=True,
+            top_bones=top_bones,
+        )
+    if asset_scope in {"models", "animations"}:
+        animation_mismatches: list[str] = []
+        texture_mismatches: list[str] = []
+        sound_mismatches: list[str] = []
+        texture_details: list[str] = []
+        sound_details: list[str] = []
+        animation_details: list[str] = []
+        if asset_scope == "animations":
+            animation_mismatches, animation_details = _verify_json_group(
+                left_root,
+                right_root,
+                state.expected_animation_files,
+                kind="animation",
+                model=False,
+                top_bones=top_bones,
+            )
+    else:
+        animation_mismatches, animation_details = _verify_json_group(
+            left_root,
+            right_root,
+            state.expected_animation_files,
+            kind="animation",
+            model=False,
+            top_bones=top_bones,
+        )
+        texture_mismatches, texture_details = _verify_textures(
+            left_root,
+            right_root,
+            state.expected_texture_files,
+        )
+        sound_mismatches, sound_details = _verify_sounds(
+            left_root,
+            right_root,
+            state.expected_sound_files,
+        )
+    return ComparisonReport(
+        root=right_root,
+        models_equal=not model_mismatches,
+        animations_equal=not animation_mismatches,
+        textures_equal=not texture_mismatches,
+        sounds_equal=not sound_mismatches,
+        mismatches=tuple(model_mismatches + animation_mismatches + texture_mismatches + sound_mismatches),
+        details=tuple(model_details + animation_details + texture_details + sound_details),
+    )
+
+
+def _prepare_comparison_root(root: Path) -> tuple[Path, tempfile.TemporaryDirectory[str] | None]:
+    if root.is_file() and zipfile.is_zipfile(root):
+        tmp = tempfile.TemporaryDirectory(prefix="ysm_oracle_zip_", dir="/tmp")
+        with zipfile.ZipFile(root) as zf:
+            zf.extractall(tmp.name)
+        extracted_root = Path(tmp.name)
+        children = [child for child in extracted_root.iterdir() if child.is_dir()]
+        if len(children) == 1:
+            return children[0], tmp
+        return extracted_root, tmp
+    return root, None
+
+
+def verify_legacy_pair(
+    ysm_path: Path,
+    source_root: Path | None,
+    *,
+    official_export_root: Path | None = None,
+    backend: str = "heuristic",
+    expected_format: int | None = None,
+    top_bones: int = 10,
+    asset_scope: str = "full",
+) -> VerificationReport:
+    if source_root is None and official_export_root is None:
+        best_dir, match_count, asset_count = find_best_source_oracle(ysm_path, include_archives=True)
+        if best_dir is None or match_count == 0:
+            raise SystemExit("no matching nearby source tree found and no official export root was provided")
+        source_root = best_dir
+        print(f"auto_source_root: {source_root} ({match_count}/{asset_count})")
+
+    result = decode_bom_v3(ysm_path)
+    if expected_format is not None and result.codec_format != expected_format:
+        raise SystemExit(f"expected format {expected_format}, got {result.codec_format!r}")
+    if result.codec_format not in (1, 9, 15):
+        raise SystemExit(f"expected legacy format 1/9/15, got {result.codec_format!r}")
+    state = parse_legacy_native_state(ysm_path)
+
+    if backend == "heuristic":
+        with contextlib.redirect_stdout(io.StringIO()):
+            out_dir = export_bom_v3_assets(
+                ysm_path,
+                result.codec_format,
+                scan_assets=False,
+                dump_assets=False,
+                dump_folder=True,
+                debug=False,
+            )
+    elif backend == "native_lift":
+        out_dir = export_legacy_native_lift(
+            ysm_path,
+        )
+    else:
+        raise SystemExit(f"unsupported backend {backend!r}")
+
+    source_report = None
+    official_report = None
+    official_vs_source_report = None
+    source_compare_root: Path | None = None
+    official_compare_root: Path | None = None
+    source_tmp: tempfile.TemporaryDirectory[str] | None = None
+    official_tmp: tempfile.TemporaryDirectory[str] | None = None
+    try:
+        if source_root is not None:
+            source_compare_root, source_tmp = _prepare_comparison_root(source_root)
+            source_report = _compare_export_tree(
+                out_dir,
+                source_compare_root,
+                state=state,
+                top_bones=top_bones,
+                asset_scope=asset_scope,
+            )
+        if official_export_root is not None:
+            official_compare_root, official_tmp = _prepare_comparison_root(official_export_root)
+            official_report = _compare_export_tree(
+                out_dir,
+                official_compare_root,
+                state=state,
+                top_bones=top_bones,
+                asset_scope=asset_scope,
+            )
+            if source_compare_root is not None:
+                official_vs_source_report = _compare_export_tree(
+                    official_compare_root,
+                    source_compare_root,
+                    state=state,
+                    top_bones=top_bones,
+                    asset_scope=asset_scope,
+                )
+    finally:
+        if source_tmp is not None:
+            source_tmp.cleanup()
+        if official_tmp is not None:
+            official_tmp.cleanup()
+
+    return VerificationReport(
+        ysm_path=ysm_path,
+        codec_format=result.codec_format,
+        backend=backend,
+        dump_folder=out_dir,
+        source_root=source_root,
+        source_report=source_report,
+        official_report=official_report,
+        official_vs_source_report=official_vs_source_report,
+    )
+
+
+def _print_report(report: VerificationReport, *, show_official: bool, official_jar: Path | None) -> None:
+    if show_official:
+        baseline = probe_ysm262_official(official_jar)
+        if baseline is not None:
+            print(f"official_jar: {baseline.jar_path}")
+            print(f"official_jar_sha256: {baseline.jar_sha256}")
+            print(f"official_native_entries: {', '.join(baseline.native_entries) or '-'}")
+            if baseline.native_sha256:
+                print(f"official_native_sha256: {', '.join(baseline.native_sha256)}")
+            if baseline.loader_classes:
+                print(f"official_loader_classes: {', '.join(baseline.loader_classes)}")
+            if baseline.export_classes:
+                print(f"official_export_classes: {', '.join(baseline.export_classes)}")
+        else:
+            print("official_jar: not_found")
+
+    print(f"file: {report.ysm_path}")
+    print(f"codec_format: {report.codec_format}")
+    print(f"backend: {report.backend}")
+    print(f"source_root: {report.source_root if report.source_root is not None else '-'}")
+    print(f"dump_folder: {report.dump_folder}")
+    print(f"models_equal: {str(report.models_equal).lower()}")
+    print(f"animations_equal: {str(report.animations_equal).lower()}")
+    print(f"textures_equal: {str(report.textures_equal).lower()}")
+    print(f"sounds_equal: {str(report.sounds_equal).lower()}")
+    print(f"overall_equivalent: {str(report.overall_equivalent).lower()}")
+    for item in report.mismatches:
+        print(f"mismatch: {item}")
+    for item in report.details:
+        print(f"detail: {item}")
+    if report.official_report is not None:
+        print(f"official_export_root: {report.official_report.root}")
+        print(f"python_vs_official_models_equal: {str(report.official_report.models_equal).lower()}")
+        print(f"python_vs_official_animations_equal: {str(report.official_report.animations_equal).lower()}")
+        print(f"python_vs_official_textures_equal: {str(report.official_report.textures_equal).lower()}")
+        print(f"python_vs_official_sounds_equal: {str(report.official_report.sounds_equal).lower()}")
+        print(f"python_vs_official_overall_equivalent: {str(report.official_report.overall_equivalent).lower()}")
+        for item in report.official_report.mismatches:
+            print(f"python_vs_official_mismatch: {item}")
+        for item in report.official_report.details:
+            print(f"python_vs_official_detail: {item}")
+    if report.official_vs_source_report is not None:
+        print(f"official_vs_source_root: {report.official_vs_source_report.root}")
+        print(f"official_vs_source_models_equal: {str(report.official_vs_source_report.models_equal).lower()}")
+        print(f"official_vs_source_animations_equal: {str(report.official_vs_source_report.animations_equal).lower()}")
+        print(f"official_vs_source_textures_equal: {str(report.official_vs_source_report.textures_equal).lower()}")
+        print(f"official_vs_source_sounds_equal: {str(report.official_vs_source_report.sounds_equal).lower()}")
+        print(f"official_vs_source_overall_equivalent: {str(report.official_vs_source_report.overall_equivalent).lower()}")
+        for item in report.official_vs_source_report.mismatches:
+            print(f"official_vs_source_mismatch: {item}")
+        for item in report.official_vs_source_report.details:
+            print(f"official_vs_source_detail: {item}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Verify legacy format 1/9/15 extraction against a paired source tree and/or official export snapshot."
+    )
+    ap.add_argument("ysm_path", type=Path)
+    ap.add_argument(
+        "--backend",
+        choices=("heuristic", "native_lift"),
+        default="heuristic",
+        help="which Python extraction lane to verify",
+    )
+    ap.add_argument(
+        "--source-root",
+        type=Path,
+        help="paired source tree; if omitted, auto-discover the best nearby source-oracle candidate when required",
+    )
+    ap.add_argument(
+        "--official-export-root",
+        type=Path,
+        help="optional official 2.6.2 export snapshot or export root for direct python-vs-official comparison",
+    )
+    ap.add_argument("--expected-format", type=int, choices=(1, 9, 15))
+    ap.add_argument(
+        "--asset-scope",
+        choices=("full", "models", "animations"),
+        default="full",
+        help="compare the full declared export set, only model JSONs, or only animation JSONs",
+    )
+    ap.add_argument("--top-bones", type=int, default=10, help="number of top per-bone deltas to print")
+    ap.add_argument("--official-jar", type=Path, help="override the 2.6.2 official jar path for baseline reporting")
+    ap.add_argument(
+        "--no-official-baseline",
+        action="store_true",
+        help="skip printing the official 2.6.2 jar/native/export baseline summary",
+    )
+    args = ap.parse_args()
+
+    report = verify_legacy_pair(
+        args.ysm_path,
+        args.source_root,
+        official_export_root=args.official_export_root,
+        backend=args.backend,
+        expected_format=args.expected_format,
+        top_bones=args.top_bones,
+        asset_scope=args.asset_scope,
+    )
+    _print_report(
+        report,
+        show_official=not args.no_official_baseline,
+        official_jar=args.official_jar,
+    )
+    return 0 if report.overall_equivalent else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/extractors/ysgp_compact_v2_parser.py
+++ b/tools/ysm_extractor/extractors/ysgp_compact_v2_parser.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+MAGIC = b"YSGP"
+VERSION_V2_BE = 2
+HEADER_MD5_SIZE = 0x10
+
+
+def _u32be(data: bytes, off: int) -> int:
+    return int.from_bytes(data[off:off + 4], "big")
+
+
+@dataclass(frozen=True)
+class CompactV2Entry:
+    index: int
+    entry_offset: int
+    name_b64: bytes
+    name_decoded: str | None
+    payload_len: int
+    key_len: int
+    entry_id: bytes
+    payload_offset: int
+    key_offset: int
+
+
+@dataclass(frozen=True)
+class CompactV2File:
+    path: Path
+    version_be: int
+    header_md5_16: bytes
+    header_md5_verified: bool
+    entries: list[CompactV2Entry]
+
+
+def parse_compact_v2_file(path: Path) -> CompactV2File:
+    data = path.read_bytes()
+    if len(data) < 8 + HEADER_MD5_SIZE:
+        raise ValueError("file too short for compact YSGP v2 container")
+    if data[:4] != MAGIC:
+        raise ValueError("file does not start with YSGP")
+    version = _u32be(data, 4)
+    if version != VERSION_V2_BE:
+        raise ValueError(f"expected compact v2 big-endian version 2, got {version}")
+
+    header_md5_16 = data[8:24]
+    off = 24
+    entries: list[CompactV2Entry] = []
+    while off < len(data):
+        remaining = len(data) - off
+        if remaining < 4:
+            raise ValueError(f"truncated compact entry header at 0x{off:x}")
+
+        name_len = _u32be(data, off)
+        name_off = off + 4
+        if name_off + name_len + 24 > len(data):
+            raise ValueError(f"compact entry name overruns file at 0x{off:x}")
+
+        name_b64 = data[name_off:name_off + name_len]
+        try:
+            name_decoded = base64.b64decode(name_b64, validate=True).decode("utf-8")
+        except Exception:
+            name_decoded = None
+
+        payload_meta_off = name_off + name_len
+        payload_len = _u32be(data, payload_meta_off)
+        key_len = _u32be(data, payload_meta_off + 4)
+        entry_id = data[payload_meta_off + 8:payload_meta_off + 24]
+        payload_off = payload_meta_off + 24
+        key_off = payload_off + payload_len
+        next_off = key_off + key_len
+
+        if next_off > len(data):
+            raise ValueError(f"compact entry data overruns file at 0x{off:x}")
+
+        entries.append(
+            CompactV2Entry(
+                index=len(entries),
+                entry_offset=off,
+                entry_id=entry_id,
+                name_b64=name_b64,
+                name_decoded=name_decoded,
+                payload_len=payload_len,
+                key_len=key_len,
+                payload_offset=payload_off,
+                key_offset=key_off,
+            )
+        )
+        off = next_off
+
+    if off != len(data):
+        raise ValueError(f"compact v2 parser did not consume full file, stopped at 0x{off:x}")
+
+    return CompactV2File(
+        path=path,
+        version_be=version,
+        header_md5_16=header_md5_16,
+        header_md5_verified=hashlib.md5(data[24:]).digest() == header_md5_16,
+        entries=entries,
+    )
+
+
+def extract_entry_payloads(container: CompactV2File) -> list[tuple[CompactV2Entry, bytes, bytes]]:
+    data = container.path.read_bytes()
+    out: list[tuple[CompactV2Entry, bytes, bytes]] = []
+    for entry in container.entries:
+        payload = data[entry.payload_offset:entry.payload_offset + entry.payload_len]
+        key = data[entry.key_offset:entry.key_offset + entry.key_len]
+        out.append((entry, payload, key))
+    return out
+
+
+def print_compact_v2(container: CompactV2File) -> None:
+    print(f"compact_v2.version_be: {container.version_be}")
+    print(f"compact_v2.header_md5_16: {container.header_md5_16.hex()}")
+    print(f"compact_v2.header_md5_verified: {container.header_md5_verified}")
+    print(f"compact_v2.entries: {len(container.entries)}")
+    for entry in container.entries:
+        name = entry.name_decoded if entry.name_decoded is not None else entry.name_b64.decode("ascii", "replace")
+        print(
+            f"entry[{entry.index}] off=0x{entry.entry_offset:x} id={entry.entry_id.hex()} "
+            f"name={name!r} payload_len=0x{entry.payload_len:x} key_len=0x{entry.key_len:x} "
+            f"payload_off=0x{entry.payload_offset:x} key_off=0x{entry.key_offset:x}"
+        )
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Static parser for compact YSGP v2 containers with repeated named entries."
+    )
+    parser.add_argument("inputs", nargs="+")
+    return parser
+
+
+def main() -> int:
+    args = build_argparser().parse_args()
+    for idx, input_path in enumerate(args.inputs):
+        if idx:
+            print()
+        container = parse_compact_v2_file(Path(input_path))
+        print(f"file: {input_path}")
+        print_compact_v2(container)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/extractors/ysgp_container_scanner.py
+++ b/tools/ysm_extractor/extractors/ysgp_container_scanner.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import argparse
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+
+WINDOW_SIZE = 512
+MERGE_GAP = 128
+PRINTABLE_ASCII = set(range(0x20, 0x7F))
+TEXT_WHITESPACE = {0x09, 0x0A, 0x0D}
+
+
+@dataclass(frozen=True)
+class ChunkReport:
+    start: int
+    end: int
+    ascii_ratio: float
+    entropy: float
+    first64_hex: str
+    dump_path: Path
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    path: Path
+    has_utf8_bom: bool
+    has_ysgp_magic: bool
+    property_end: int
+    property_text: str
+    chunks: list[ChunkReport]
+
+
+def shannon_entropy(data: bytes) -> float:
+    if not data:
+        return 0.0
+    counts = [0] * 256
+    for b in data:
+        counts[b] += 1
+    entropy = 0.0
+    n = len(data)
+    for count in counts:
+        if count == 0:
+            continue
+        p = count / n
+        entropy -= p * math.log2(p)
+    return entropy
+
+
+def ascii_ratio(data: bytes) -> float:
+    if not data:
+        return 1.0
+    ascii_like = 0
+    for b in data:
+        if b in PRINTABLE_ASCII or b in TEXT_WHITESPACE:
+            ascii_like += 1
+    return ascii_like / len(data)
+
+
+def utf8_text_score(data: bytes) -> tuple[bool, float]:
+    if not data:
+        return True, 1.0
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False, 0.0
+
+    printable = 0
+    for ch in text:
+        if ch.isprintable() or ch in "\r\n\t":
+            printable += 1
+    return True, printable / max(1, len(text))
+
+
+def is_probably_text_window(data: bytes) -> bool:
+    if not data:
+        return False
+    if b"\x00" in data:
+        return False
+    utf8_ok, printable_ratio = utf8_text_score(data)
+    if not utf8_ok:
+        return False
+    return printable_ratio >= 0.70
+
+
+def detect_property_end(data: bytes) -> int:
+    if not data:
+        return 0
+
+    cursor = 0
+    if data.startswith(b"\xef\xbb\xbf"):
+        cursor = 3
+    if data[cursor:cursor + 4] == b"YSGP":
+        cursor += 4
+
+    pos = cursor
+    refined = cursor
+    while pos < len(data):
+        next_nl = data.find(b"\n", pos)
+        if next_nl == -1:
+            next_nl = len(data)
+        else:
+            next_nl += 1
+        line = data[pos:next_nl]
+        if not line:
+            break
+        if is_probably_text_window(line):
+            refined = next_nl
+            pos = next_nl
+            continue
+        break
+
+    return refined
+
+
+def detect_binary_chunks(data: bytes, start: int) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    in_chunk = False
+    chunk_start = start
+    pos = start
+
+    while pos < len(data):
+        window = data[pos:pos + WINDOW_SIZE]
+        if not window:
+            break
+        text_like = is_probably_text_window(window)
+        if not text_like:
+            if not in_chunk:
+                in_chunk = True
+                chunk_start = pos
+        else:
+            if in_chunk:
+                spans.append((chunk_start, pos))
+                in_chunk = False
+        pos += WINDOW_SIZE
+
+    if in_chunk:
+        spans.append((chunk_start, len(data)))
+
+    if not spans:
+        return []
+
+    merged: list[tuple[int, int]] = [spans[0]]
+    for start_i, end_i in spans[1:]:
+        prev_start, prev_end = merged[-1]
+        if start_i - prev_end <= MERGE_GAP:
+            merged[-1] = (prev_start, end_i)
+        else:
+            merged.append((start_i, end_i))
+    return merged
+
+
+def dump_chunk(input_path: Path, index: int, start: int, end: int, data: bytes) -> Path:
+    out = input_path.with_name(
+        f"{input_path.stem}.chunk_{index:02d}.{start:08x}-{end:08x}.bin"
+    )
+    out.write_bytes(data[start:end])
+    return out
+
+
+def scan_file(path: Path, dump: bool = True) -> ScanResult:
+    data = path.read_bytes()
+    has_utf8_bom = data.startswith(b"\xef\xbb\xbf")
+    magic_off = 3 if has_utf8_bom else 0
+    has_ysgp_magic = data[magic_off:magic_off + 4] == b"YSGP"
+
+    property_end = detect_property_end(data)
+    property_bytes = data[:property_end]
+    try:
+        property_text = property_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        property_text = property_bytes.decode("utf-8", errors="replace")
+
+    chunk_reports: list[ChunkReport] = []
+    for idx, (start, end) in enumerate(detect_binary_chunks(data, property_end)):
+        chunk = data[start:end]
+        dump_path = dump_chunk(path, idx, start, end, data) if dump else path
+        chunk_reports.append(
+            ChunkReport(
+                start=start,
+                end=end,
+                ascii_ratio=ascii_ratio(chunk),
+                entropy=shannon_entropy(chunk),
+                first64_hex=chunk[:64].hex(),
+                dump_path=dump_path,
+            )
+        )
+
+    return ScanResult(
+        path=path,
+        has_utf8_bom=has_utf8_bom,
+        has_ysgp_magic=has_ysgp_magic,
+        property_end=property_end,
+        property_text=property_text,
+        chunks=chunk_reports,
+    )
+
+
+def print_scan_result(result: ScanResult, show_property: bool) -> None:
+    print(f"file: {result.path}")
+    print(f"bom_utf8: {result.has_utf8_bom}")
+    print(f"ysgp_magic: {result.has_ysgp_magic}")
+    print(f"property_end: 0x{result.property_end:08x} ({result.property_end})")
+    if show_property:
+        print("property_block_begin")
+        print(result.property_text.rstrip("\n"))
+        print("property_block_end")
+    if not result.chunks:
+        print("candidate_chunks: none")
+        return
+    print(f"candidate_chunks: {len(result.chunks)}")
+    for i, chunk in enumerate(result.chunks):
+        print(f"chunk[{i}] start=0x{chunk.start:08x} end=0x{chunk.end:08x} length=0x{chunk.length:x}")
+        print(f"chunk[{i}] ascii_ratio={chunk.ascii_ratio:.4f} entropy={chunk.entropy:.4f}")
+        print(f"chunk[{i}] first64={chunk.first64_hex}")
+        print(f"chunk[{i}] dump={chunk.dump_path}")
+
+
+def compare_results(results: list[ScanResult]) -> None:
+    print("compare_begin")
+    if not results:
+        print("no_results")
+        print("compare_end")
+        return
+
+    max_chunks = max(len(r.chunks) for r in results)
+    for result in results:
+        offsets = ", ".join(f"0x{c.start:x}" for c in result.chunks) or "none"
+        lengths = ", ".join(f"0x{c.length:x}" for c in result.chunks) or "none"
+        print(f"{result.path.name}: property_end=0x{result.property_end:x} chunks={len(result.chunks)}")
+        print(f"{result.path.name}: chunk_offsets={offsets}")
+        print(f"{result.path.name}: chunk_lengths={lengths}")
+
+    for idx in range(max_chunks):
+        print(f"candidate_index[{idx}]")
+        for result in results:
+            if idx >= len(result.chunks):
+                print(f"  {result.path.name}: missing")
+                continue
+            chunk = result.chunks[idx]
+            rel = chunk.start / max(1, result.path.stat().st_size)
+            print(
+                f"  {result.path.name}: start=0x{chunk.start:x} len=0x{chunk.length:x} "
+                f"rel_start={rel:.5f} first16={chunk.first64_hex[:32]}"
+            )
+    print("compare_end")
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Conservative YSGP headered v3 container scanner and chunk carver."
+    )
+    parser.add_argument("inputs", nargs="+", help="YSGP/.ysm files to scan")
+    parser.add_argument(
+        "--no-property",
+        action="store_true",
+        help="Do not print the decoded property block",
+    )
+    parser.add_argument(
+        "--no-dump",
+        action="store_true",
+        help="Do not dump carved candidate chunks",
+    )
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="Compare candidate chunk offsets/patterns across all input files",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_argparser()
+    args = parser.parse_args()
+
+    results = [
+        scan_file(Path(input_path), dump=not args.no_dump)
+        for input_path in args.inputs
+    ]
+
+    for idx, result in enumerate(results):
+        if idx:
+            print()
+        print_scan_result(result, show_property=not args.no_property)
+
+    if args.compare or len(results) > 1:
+        print()
+        compare_results(results)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/extractors/ysm262_official.py
+++ b/tools/ysm_extractor/extractors/ysm262_official.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import hashlib
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+YSM262_JAR_NAME = "ysm-2.6.2-forge+mc1.20.1-release.jar"
+EXPORT_MARKERS = (
+    b"commands.yes_steve_model.export.success",
+    b"commands.yes_steve_model.export.failure",
+    b"commands.yes_steve_model.export.not_exist",
+)
+LOADER_MARKER = b"libysm-core"
+
+
+@dataclass(frozen=True)
+class Ysm262OfficialBaseline:
+    jar_path: Path
+    jar_sha256: str
+    native_entries: tuple[str, ...]
+    native_sha256: tuple[str, ...]
+    export_classes: tuple[str, ...]
+    loader_classes: tuple[str, ...]
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def find_ysm262_jar(start: Path | None = None) -> Path | None:
+    root = (start or Path(__file__)).resolve()
+    if root.is_file():
+        root = root.parent
+    candidates = [root, *root.parents]
+    seen: set[Path] = set()
+    for base in candidates:
+        if base in seen:
+            continue
+        seen.add(base)
+        candidate = base / YSM262_JAR_NAME
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def probe_ysm262_official(jar_path: Path | None = None) -> Ysm262OfficialBaseline | None:
+    jar_path = jar_path or find_ysm262_jar()
+    if jar_path is None or not jar_path.is_file():
+        return None
+
+    jar_bytes = jar_path.read_bytes()
+    native_entries: list[str] = []
+    native_sha256: list[str] = []
+    export_classes: list[str] = []
+    loader_classes: list[str] = []
+
+    with zipfile.ZipFile(jar_path) as zf:
+        for name in zf.namelist():
+            if "libysm-core" in name:
+                native_entries.append(name)
+                native_sha256.append(_sha256_hex(zf.read(name)))
+                continue
+            if not name.endswith(".class"):
+                continue
+            payload = zf.read(name)
+            if any(marker in payload for marker in EXPORT_MARKERS):
+                export_classes.append(name[:-6].replace("/", "."))
+            if LOADER_MARKER in payload:
+                loader_classes.append(name[:-6].replace("/", "."))
+
+    return Ysm262OfficialBaseline(
+        jar_path=jar_path,
+        jar_sha256=_sha256_hex(jar_bytes),
+        native_entries=tuple(native_entries),
+        native_sha256=tuple(native_sha256),
+        export_classes=tuple(sorted(set(export_classes))),
+        loader_classes=tuple(sorted(set(loader_classes))),
+    )
+

--- a/tools/ysm_extractor/extractors/ysm262_oracle.py
+++ b/tools/ysm_extractor/extractors/ysm262_oracle.py
@@ -1,0 +1,3066 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import shlex
+import shutil
+import subprocess
+import textwrap
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from extractors.bom_v3_payload_assets import _read_property_format, _read_property_name, _sanitize_name
+from extractors.bom_v3_source_oracle import find_best_source_oracle
+from extractors.ysm262_official import find_ysm262_jar, probe_ysm262_official
+
+
+CANONICAL_MODEL_FILES = ("main.json", "arm.json", "arrow.json")
+CANONICAL_ANIMATION_FILES = (
+    "main.animation.json",
+    "extra.animation.json",
+    "tac.animation.json",
+    "carryon.animation.json",
+    "arrow.animation.json",
+)
+SOUND_GLOB = "*.ogg"
+PNG_GLOB = "*.png"
+DEFAULT_MINECRAFT_ROOT = Path.home() / ".minecraft"
+DEFAULT_FORGE_VERSION_ID = "1.20.1-forge-47.4.12"
+DEFAULT_FALLBACK_ROOTS = (Path.home() / ".gradle",)
+DEFAULT_FORGE_RUNTIME_COMPANIONS = ("fmlcore", "javafmllanguage", "lowcodelanguage", "mclanguage")
+DEFAULT_FORGE_MCP_VERSION = "20230612.114412"
+DEFAULT_BOOTSTRAP_MAIN_CLASS = "cpw.mods.bootstraplauncher.BootstrapLauncher"
+DEFAULT_BOOTSTRAP_IGNORE_LIST_TEMPLATE = (
+    "bootstraplauncher,securejarhandler,asm-commons,asm-util,asm-analysis,asm-tree,asm,"
+    "JarJarFileSystems,client-extra,fmlcore,javafmllanguage,lowcodelanguage,mclanguage,forge-,{version_id}.jar"
+)
+DEFAULT_MCP_CLIENT_ARTIFACT_SUFFIXES = ("srg", "extra")
+DEFAULT_HEADED_DEBUG_PROFILE_ID = "ysm-headed-debug"
+DEFAULT_HEADED_DEBUG_PROFILE_NAME = "YSM Headed Debug"
+DEFAULT_CAPTURE_PROFILE_ID_PREFIX = "ysm-headed-export"
+DEFAULT_CAPTURE_PROFILE_NAME_PREFIX = "YSM Export"
+DEFAULT_DEBUG_RUNTIME_ENV = "YSM262_DEBUG_RUNTIME_ROOT"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _default_debug_runtime_root() -> Path:
+    override = os.getenv(DEFAULT_DEBUG_RUNTIME_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    return _repo_root() / "debug_runtime"
+
+
+def _default_headed_host_out_dir() -> Path:
+    return _default_debug_runtime_root() / "headed_host_bundle"
+
+
+def _default_vm_bundle_out_dir() -> Path:
+    return _default_debug_runtime_root() / "vm_bundle_guest_gdb_use_case"
+
+
+def _default_launcher_command_out_path() -> Path:
+    return _default_debug_runtime_root() / "launcher" / "forgeclient_command_use_case.txt"
+
+
+def _default_ghidra_root() -> Path:
+    return _default_debug_runtime_root() / "ghidra"
+
+
+def _default_ghidra_reports_dir() -> Path:
+    return _default_ghidra_root() / "reports"
+
+
+@dataclass(frozen=True)
+class ExportLayout:
+    root: Path
+    model_pairs: tuple[tuple[str, str], ...]
+    animation_pairs: tuple[tuple[str, str], ...]
+    texture_root: Path
+    sound_root: Path
+
+
+@dataclass(frozen=True)
+class RuntimeClasspathEntry:
+    version_id: str
+    kind: str
+    source_path: Path
+    bundle_path: Path
+    logical_name: str
+
+
+@dataclass(frozen=True)
+class RuntimeAudit:
+    minecraft_root: Path
+    version_id: str
+    main_class: str | None
+    minecraft_version: str
+    forge_version: str | None
+    mcp_version: str | None
+    entries: tuple[RuntimeClasspathEntry, ...]
+    missing: tuple[dict[str, Any], ...]
+    searched_version_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ForgeBootstrapInfo:
+    main_class: str | None
+    minecraft_version: str
+    forge_version: str | None
+    mcp_version: str | None
+    ignore_list: str
+
+
+@dataclass(frozen=True)
+class LauncherReplayCommand:
+    source_path: Path
+    java_executable: str
+    main_class: str
+    jvm_args: tuple[str, ...]
+    game_args: tuple[str, ...]
+    launch_target: str | None
+    raw_command: str
+
+
+@dataclass(frozen=True)
+class HeadedDebugLayout:
+    root: Path
+    game_dir: Path
+    trace_dir: Path
+    scripts_dir: Path
+    native_tools_dir: Path
+    bin_dir: Path
+
+
+@dataclass(frozen=True)
+class LegacyExportCapture:
+    bundle_root: Path
+    custom_dir: Path
+    export_root: Path
+    sample_copy: Path
+    snapshot_root: Path
+    manifest_path: Path
+
+
+@dataclass(frozen=True)
+class HeadedModelTraceConfig:
+    enabled: bool = False
+    sample_hint: str | None = None
+    family_filter: tuple[str, ...] = tuple()
+    export_filter: str = "main.json"
+    trace_rel: int = 0x4E2C80
+    patch_len: int = 16
+    budget: int = 32
+    scan_bytes: int = 0x240
+    string_limit: int = 64
+    vector_limit: int = 48
+
+
+def detect_export_layout(root: Path) -> ExportLayout:
+    model_dir = root / "models"
+    animation_dir = root / "animations"
+    texture_dir = root / "textures"
+    sound_dir = root / "sounds"
+
+    if model_dir.is_dir() or animation_dir.is_dir() or texture_dir.is_dir() or sound_dir.is_dir():
+        model_pairs = tuple((name, f"models/{name}") for name in CANONICAL_MODEL_FILES)
+        animation_pairs = tuple((name, f"animations/{name}") for name in CANONICAL_ANIMATION_FILES)
+        return ExportLayout(
+            root=root,
+            model_pairs=model_pairs,
+            animation_pairs=animation_pairs,
+            texture_root=texture_dir if texture_dir.is_dir() else root,
+            sound_root=sound_dir if sound_dir.is_dir() else root,
+        )
+
+    model_pairs = tuple((name, name) for name in CANONICAL_MODEL_FILES)
+    animation_pairs = tuple((name, name) for name in CANONICAL_ANIMATION_FILES)
+    return ExportLayout(
+        root=root,
+        model_pairs=model_pairs,
+        animation_pairs=animation_pairs,
+        texture_root=root,
+        sound_root=root,
+    )
+
+
+def _clear_known_output_dir(out_dir: Path, patterns: Sequence[str]) -> None:
+    for pattern in patterns:
+        for path in out_dir.glob(pattern):
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink(missing_ok=True)
+
+
+def _clear_dir_children(root: Path) -> None:
+    if not root.exists():
+        return
+    for child in root.iterdir():
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child)
+        else:
+            child.unlink(missing_ok=True)
+
+
+def _legacy_capture_stem(path: Path) -> str:
+    return _sanitize_name(path.stem) or "legacy_capture"
+
+
+def _default_capture_out_dir(ysm_path: Path) -> Path:
+    return ysm_path.parent / f".tmp_headed_export_{_legacy_capture_stem(ysm_path)}"
+
+
+def _default_capture_profile_id(ysm_path: Path) -> str:
+    return f"{DEFAULT_CAPTURE_PROFILE_ID_PREFIX}-{_legacy_capture_stem(ysm_path)}"
+
+
+def _default_capture_profile_name(ysm_path: Path) -> str:
+    display_name = _read_property_name(ysm_path) or ysm_path.stem
+    compact = re.sub(r"\s+", " ", display_name).strip()
+    compact = compact[:48].rstrip() if compact else ysm_path.stem
+    return f"{DEFAULT_CAPTURE_PROFILE_NAME_PREFIX} {compact}"
+
+
+def _default_capture_profile_identity(
+    ysm_path: Path,
+    *,
+    out_dir: Path,
+    model_trace: HeadedModelTraceConfig,
+) -> tuple[str, str]:
+    profile_id = _default_capture_profile_id(ysm_path)
+    profile_name = _default_capture_profile_name(ysm_path)
+    if model_trace.enabled and model_trace.trace_rel != 0x4E2C80:
+        hook_suffix = f"hook-{model_trace.trace_rel:x}"
+        profile_id = f"{profile_id}-{hook_suffix}"
+        profile_name = f"{profile_name} ({hook_suffix})"
+        return profile_id, profile_name
+    default_out_dir = _default_capture_out_dir(ysm_path).resolve()
+    if out_dir != default_out_dir:
+        out_suffix = _sanitize_name(out_dir.name) or "capture"
+        profile_id = f"{profile_id}-{out_suffix}"
+        profile_name = f"{profile_name} ({out_suffix[:24]})"
+    return profile_id, profile_name
+
+
+def _parse_model_trace_family_filter(raw: str | None) -> tuple[str, ...]:
+    if raw is None:
+        return tuple()
+    values = [item.strip() for item in raw.split(",")]
+    return tuple(item for item in values if item)
+
+
+def _max_tree_mtime(root: Path) -> float:
+    latest = root.stat().st_mtime
+    for path in root.rglob("*"):
+        try:
+            latest = max(latest, path.stat().st_mtime)
+        except FileNotFoundError:
+            continue
+    return latest
+
+
+def _layout_file_count(layout: ExportLayout) -> int:
+    count = sum(1 for canonical_name, relpath in layout.model_pairs if (layout.root / relpath).is_file())
+    count += sum(1 for canonical_name, relpath in layout.animation_pairs if (layout.root / relpath).is_file())
+    count += sum(1 for path in layout.texture_root.glob(PNG_GLOB) if path.is_file())
+    count += sum(1 for path in layout.sound_root.glob(SOUND_GLOB) if path.is_file())
+    return count
+
+
+def _is_export_payload_root(root: Path) -> bool:
+    if not root.is_dir():
+        return False
+    layout = detect_export_layout(root)
+    return _layout_file_count(layout) > 0
+
+
+def _candidate_export_roots(export_root: Path) -> list[Path]:
+    if not export_root.is_dir():
+        return []
+    candidates: list[Path] = []
+    for root in [export_root, *(path for path in export_root.rglob("*") if path.is_dir())]:
+        if _is_export_payload_root(root):
+            candidates.append(root)
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for root in sorted(candidates):
+        if root in seen:
+            continue
+        seen.add(root)
+        deduped.append(root)
+    return deduped
+
+
+def _select_export_root(candidates: Sequence[Path], *, model_id: str) -> Path | None:
+    if not candidates:
+        return None
+
+    def score(root: Path) -> tuple[int, int, float]:
+        parts = {part.lower() for part in root.parts}
+        id_score = 1 if model_id.lower() in parts or model_id.lower() in root.name.lower() else 0
+        file_score = _layout_file_count(detect_export_layout(root))
+        mtime = _max_tree_mtime(root)
+        return (id_score, file_score, mtime)
+
+    return max(candidates, key=score)
+
+
+def _hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _platform_rule_name() -> str:
+    if sys_platform := platform.system().lower():
+        if sys_platform.startswith("linux"):
+            return "linux"
+        if sys_platform.startswith("darwin"):
+            return "osx"
+        if sys_platform.startswith("windows"):
+            return "windows"
+    return platform.system().lower()
+
+
+def _platform_arch() -> str:
+    machine = platform.machine().lower()
+    if machine in {"x86_64", "amd64"}:
+        return "x86_64"
+    if machine in {"aarch64", "arm64"}:
+        return "arm64"
+    return machine
+
+
+def _rules_allow(library: dict[str, Any]) -> bool:
+    rules = library.get("rules")
+    if not rules:
+        return True
+
+    os_name = _platform_rule_name()
+    arch = _platform_arch()
+    allowed = False
+    for rule in rules:
+        action = rule.get("action")
+        if action not in {"allow", "disallow"}:
+            continue
+        matches = True
+        os_rule = rule.get("os") or {}
+        if os_rule.get("name") and os_rule["name"] != os_name:
+            matches = False
+        if os_rule.get("arch") and os_rule["arch"] != arch:
+            matches = False
+        if rule.get("features"):
+            matches = False
+        if matches:
+            allowed = action == "allow"
+    return allowed
+
+
+def _load_version_manifest(minecraft_root: Path, version_id: str) -> tuple[Path, dict[str, Any]]:
+    path = minecraft_root / "versions" / version_id / f"{version_id}.json"
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return path, json.loads(path.read_text(encoding="utf-8"))
+
+
+def _find_fallback_artifact(relative_path: str, fallback_roots: Sequence[Path]) -> Path | None:
+    rel = Path(relative_path)
+    for root in fallback_roots:
+        direct = root / rel
+        if direct.is_file():
+            return direct
+        matches = list(root.rglob(rel.name))
+        if matches:
+            return matches[0]
+    return None
+
+
+def _extract_argument_value(arguments: Sequence[Any], flag: str) -> str | None:
+    for index, value in enumerate(arguments):
+        if value == flag and index + 1 < len(arguments):
+            next_value = arguments[index + 1]
+            if isinstance(next_value, str):
+                return next_value
+        if isinstance(value, str) and value.startswith(f"{flag}="):
+            return value.split("=", 1)[1]
+    return None
+
+
+def _find_jvm_property(arguments: Sequence[Any], name: str) -> str | None:
+    prefix = f"-D{name}="
+    for value in arguments:
+        if isinstance(value, str) and value.startswith(prefix):
+            return value[len(prefix) :]
+    return None
+
+
+def _parse_launcher_command_file(
+    command_file: Path,
+    *,
+    expected_main_classes: Sequence[str],
+) -> LauncherReplayCommand:
+    raw_command = command_file.read_text(encoding="utf-8").strip()
+    if not raw_command:
+        raise ValueError(f"launcher command file was empty: {command_file}")
+    tokens = shlex.split(raw_command)
+    if not tokens:
+        raise ValueError(f"launcher command file had no tokens: {command_file}")
+
+    if tokens[0] == "gdb":
+        if "--args" not in tokens:
+            raise ValueError("captured launcher command starts with gdb but has no --args separator")
+        tokens = tokens[tokens.index("--args") + 1 :]
+        if not tokens:
+            raise ValueError("captured launcher command had no java invocation after --args")
+
+    java_executable = tokens[0]
+    main_class_index = -1
+    for candidate in expected_main_classes:
+        if not candidate:
+            continue
+        try:
+            main_class_index = tokens.index(candidate, 1)
+            break
+        except ValueError:
+            continue
+    if main_class_index < 0:
+        raise ValueError(
+            "could not locate the launcher main class in the captured command; "
+            f"looked for: {', '.join(candidate for candidate in expected_main_classes if candidate)}"
+        )
+
+    main_class = tokens[main_class_index]
+    jvm_args = tuple(tokens[1:main_class_index])
+    game_args = tuple(tokens[main_class_index + 1 :])
+    return LauncherReplayCommand(
+        source_path=command_file,
+        java_executable=java_executable,
+        main_class=main_class,
+        jvm_args=jvm_args,
+        game_args=game_args,
+        launch_target=_extract_argument_value(game_args, "--launchTarget"),
+        raw_command=raw_command,
+    )
+
+
+def _shell_quote_lines(values: Sequence[str]) -> str:
+    return "\n".join(f"  {shlex.quote(value)}" for value in values)
+
+
+def _write_launcher_replay_artifacts(
+    out_dir: Path,
+    *,
+    command: LauncherReplayCommand,
+    linux_native_name: str | None,
+) -> dict[str, Any]:
+    if linux_native_name is None:
+        return {}
+
+    runtime_dir = out_dir / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    scripts_dir = out_dir / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+
+    override_flags = {
+        "--username": "YSM262_FORGECLIENT_USERNAME",
+        "--gameDir": "YSM262_FORGECLIENT_GAME_DIR",
+        "--assetsDir": "YSM262_FORGECLIENT_ASSETS_DIR",
+        "--assetIndex": "YSM262_FORGECLIENT_ASSET_INDEX",
+        "--uuid": "YSM262_FORGECLIENT_UUID",
+        "--accessToken": "YSM262_FORGECLIENT_ACCESS_TOKEN",
+        "--clientId": "YSM262_FORGECLIENT_CLIENT_ID",
+        "--xuid": "YSM262_FORGECLIENT_XUID",
+        "--userType": "YSM262_FORGECLIENT_USER_TYPE",
+        "--versionType": "YSM262_FORGECLIENT_VERSION_TYPE",
+        "--quickPlayPath": "YSM262_FORGECLIENT_QUICK_PLAY_PATH",
+    }
+
+    captured_env_values: dict[str, str] = {}
+    game_array_lines: list[str] = []
+    index = 0
+    while index < len(command.game_args):
+        token = command.game_args[index]
+        env_var = override_flags.get(token)
+        if env_var and index + 1 < len(command.game_args):
+            value = command.game_args[index + 1]
+            captured_env_values[env_var] = value
+            game_array_lines.append(f"  {shlex.quote(token)}")
+            game_array_lines.append(f'  "${{{env_var}}}"')
+            index += 2
+            continue
+        game_array_lines.append(f"  {shlex.quote(token)}")
+        index += 1
+
+    env_example_lines = [
+        "# Optional overrides for scripts/run_forgeclient_replay.sh",
+        "# Copy to forgeclient_session.env and replace values as needed.",
+        "",
+    ]
+    env_runtime_lines = [
+        "# Bundle-local captured session values for scripts/run_forgeclient_replay.sh",
+        "# Regenerate or edit if the launcher session changes.",
+        "",
+    ]
+    for flag, env_var in override_flags.items():
+        captured = captured_env_values.get(env_var, "")
+        rendered_value = shlex.quote(captured) if captured else "''"
+        env_example_lines.append(f"{env_var}={rendered_value}")
+        env_runtime_lines.append(f"{env_var}={rendered_value}")
+    env_example_lines.append("")
+    env_runtime_lines.append("")
+    env_example = runtime_dir / "forgeclient_session.env.example"
+    env_example.write_text("\n".join(env_example_lines), encoding="utf-8")
+    env_runtime = runtime_dir / "forgeclient_session.env"
+    env_runtime.write_text("\n".join(env_runtime_lines), encoding="utf-8")
+
+    replay_manifest = {
+        "source_command_file": str(command.source_path),
+        "java_executable": command.java_executable,
+        "main_class": command.main_class,
+        "launch_target": command.launch_target,
+        "jvm_arg_count": len(command.jvm_args),
+        "game_arg_count": len(command.game_args),
+        "override_env_vars": list(override_flags.values()),
+        "captured_jvm_properties": {
+            name: _find_jvm_property(command.jvm_args, name)
+            for name in (
+                "java.library.path",
+                "jna.tmpdir",
+                "org.lwjgl.system.SharedLibraryExtractPath",
+                "io.netty.native.workdir",
+                "minecraft.launcher.brand",
+                "minecraft.launcher.version",
+                "ignoreList",
+                "mergeModules",
+                "libraryDirectory",
+            )
+            if _find_jvm_property(command.jvm_args, name) is not None
+        },
+    }
+    manifest_path = runtime_dir / "forgeclient_replay_manifest.json"
+    manifest_path.write_text(json.dumps(replay_manifest, indent=2), encoding="utf-8")
+
+    jvm_array_lines = _shell_quote_lines(command.jvm_args)
+    game_array_lines_rendered = "\n".join(game_array_lines)
+    replay_script = (
+        textwrap.dedent(
+        f"""\
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${{BASH_SOURCE[0]}}")/.." && pwd)
+BUILD_DIR="$ROOT/build/forgeclient_replay"
+REAL_JAVA_EXE=$(readlink -f "$(command -v java)")
+JAVA_HOME_DIR=$(dirname "$(dirname "$REAL_JAVA_EXE")")
+NATIVE_LIB="$ROOT/native/{linux_native_name}"
+DEFAULT_JAVA_EXE={shlex.quote(command.java_executable)}
+SESSION_ENV_FILE="${{YSM262_FORGECLIENT_SESSION_ENV:-$ROOT/runtime/forgeclient_session.env}}"
+DEFAULT_PID_FILE="$ROOT/runtime/forgeclient_replay.pid"
+PRELOAD_MODE=off
+USE_GDB=0
+DRY_RUN=0
+GDB_SCRIPT="$ROOT/gdb/ysm262_antidebug_min.gdb"
+PID_FILE="${{YSM262_PID_FILE:-$DEFAULT_PID_FILE}}"
+PAUSE_BEFORE_EXEC_MS=""
+ALLOW_PTRACE_ANY=0
+
+if [[ -f "$SESSION_ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$SESSION_ENV_FILE"
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --preload-mode)
+      PRELOAD_MODE="${{2:-}}"
+      shift 2
+      ;;
+    --gdb)
+      USE_GDB=1
+      shift
+      ;;
+    --gdb-script)
+      GDB_SCRIPT="${{2:-}}"
+      shift 2
+      ;;
+    --pid-file)
+      PID_FILE="${{2:-}}"
+      shift 2
+      ;;
+    --pause-before-exec-ms)
+      PAUSE_BEFORE_EXEC_MS="${{2:-}}"
+      shift 2
+      ;;
+    --allow-ptrace-any)
+      ALLOW_PTRACE_ANY=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --help|-h)
+      printf '%s\\n' \
+        "usage: run_forgeclient_replay.sh [--preload-mode off|log|spoof] [--gdb] [--gdb-script /path/to/script.gdb] [--pid-file runtime/forgeclient_replay.pid] [--pause-before-exec-ms N] [--allow-ptrace-any] [--dry-run]" \
+        "" \
+        "notes:" \
+        "  - replays a captured launcher-faithful forgeclient Java command" \
+        "  - bundle-local session overrides are loaded from runtime/forgeclient_session.env when present" \
+        "  - preload spoof mode reuses the same interposer defaults as the other VM probe launchers" \
+        "  - --gdb defaults to the minimal anti-debug preset gdb/ysm262_antidebug_min.gdb" \
+        "  - --pid-file defaults to runtime/forgeclient_replay.pid and writes the exact replay PID before exec" \
+        "  - --pause-before-exec-ms keeps the pre-exec shell alive with that same PID before it becomes java" \
+        "  - --allow-ptrace-any opts the replay target into same-user ptrace attaches under Yama ptrace_scope=1" \
+        "  - --dry-run prints the final command after env overrides and exits"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+JAVA_EXE="${{YSM262_FORGECLIENT_JAVA_EXE:-$DEFAULT_JAVA_EXE}}"
+YSM262_FORGECLIENT_USERNAME=${{YSM262_FORGECLIENT_USERNAME:-''}}
+YSM262_FORGECLIENT_GAME_DIR=${{YSM262_FORGECLIENT_GAME_DIR:-''}}
+YSM262_FORGECLIENT_ASSETS_DIR=${{YSM262_FORGECLIENT_ASSETS_DIR:-''}}
+YSM262_FORGECLIENT_ASSET_INDEX=${{YSM262_FORGECLIENT_ASSET_INDEX:-''}}
+YSM262_FORGECLIENT_UUID=${{YSM262_FORGECLIENT_UUID:-''}}
+YSM262_FORGECLIENT_ACCESS_TOKEN=${{YSM262_FORGECLIENT_ACCESS_TOKEN:-''}}
+YSM262_FORGECLIENT_CLIENT_ID=${{YSM262_FORGECLIENT_CLIENT_ID:-''}}
+YSM262_FORGECLIENT_XUID=${{YSM262_FORGECLIENT_XUID:-''}}
+YSM262_FORGECLIENT_USER_TYPE=${{YSM262_FORGECLIENT_USER_TYPE:-''}}
+YSM262_FORGECLIENT_VERSION_TYPE=${{YSM262_FORGECLIENT_VERSION_TYPE:-''}}
+YSM262_FORGECLIENT_QUICK_PLAY_PATH=${{YSM262_FORGECLIENT_QUICK_PLAY_PATH:-''}}
+
+if [[ "$PRELOAD_MODE" != "off" ]]; then
+  mkdir -p "$BUILD_DIR"
+  cc -shared -fPIC -O0 -g "$ROOT/native_tools/ysm262_intercept.c" \\
+    -I"$JAVA_HOME_DIR/include" -I"$JAVA_HOME_DIR/include/linux" -pthread -ldl \\
+    -o "$BUILD_DIR/libysm262_intercept.so"
+  export LD_PRELOAD="$BUILD_DIR/libysm262_intercept.so${{LD_PRELOAD:+:$LD_PRELOAD}}"
+  export YSM262_INTERCEPT_LOG="${{YSM262_INTERCEPT_LOG:-$BUILD_DIR/ysm262_intercept.log}}"
+  if [[ "$PRELOAD_MODE" == "spoof" ]]; then
+    export YSM262_SPOOF_PROC_SELF_EXE="${{YSM262_SPOOF_PROC_SELF_EXE:-$JAVA_EXE}}"
+    export YSM262_SPOOF_DLADDR_LIBJVM="${{YSM262_SPOOF_DLADDR_LIBJVM:-$JAVA_HOME_DIR/lib/server/libjvm.so}}"
+    export YSM262_SPOOF_DLADDR_JVM_ORIGINS="${{YSM262_SPOOF_DLADDR_JVM_ORIGINS:-1}}"
+    export YSM262_SPOOF_PRCTL_VM="1"
+    export YSM262_SPOOF_HOSTNAME="${{YSM262_SPOOF_HOSTNAME:-localhost}}"
+    export YSM262_SPOOF_AFFINITY_ONECPU="${{YSM262_SPOOF_AFFINITY_ONECPU:-1}}"
+  fi
+fi
+
+if [[ -n "$PID_FILE" ]]; then
+  ALLOW_PTRACE_ANY=1
+fi
+
+JAVA_ARGS=(
+__YSM262_JVM_ARRAY_LINES__
+  {shlex.quote(command.main_class)}
+)
+
+GAME_ARGS=(
+__YSM262_GAME_ARRAY_LINES__
+)
+
+JAVA_ARGS+=("${{GAME_ARGS[@]}}")
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf '%q ' "$JAVA_EXE" "${{JAVA_ARGS[@]}}"
+  printf '\\n'
+  exit 0
+fi
+
+if [[ -n "$PID_FILE" ]]; then
+  mkdir -p "$(dirname "$PID_FILE")"
+  printf '%s\\n' "$$" > "$PID_FILE"
+fi
+
+if [[ -n "$PAUSE_BEFORE_EXEC_MS" ]]; then
+  python3 - "$PAUSE_BEFORE_EXEC_MS" <<'PY'
+import sys
+import time
+
+time.sleep(max(0.0, float(sys.argv[1]) / 1000.0))
+PY
+fi
+
+if [[ "$USE_GDB" -eq 1 ]]; then
+  GDB_ARGS=("-q")
+  if [[ -n "$GDB_SCRIPT" ]]; then
+    GDB_ARGS+=("-ex" "source $GDB_SCRIPT")
+  fi
+  exec gdb "${{GDB_ARGS[@]}}" --args "$JAVA_EXE" "${{JAVA_ARGS[@]}}"
+fi
+
+if [[ "$ALLOW_PTRACE_ANY" -eq 1 ]]; then
+  mkdir -p "$BUILD_DIR"
+  cc -O2 -g "$ROOT/native_tools/ysm262_ptrace_exec.c" -o "$BUILD_DIR/ysm262_ptrace_exec"
+  if [[ -n "$PID_FILE" ]]; then
+    export YSM262_PTRACE_EXEC_STOP="${{YSM262_PTRACE_EXEC_STOP:-1}}"
+  fi
+  exec "$BUILD_DIR/ysm262_ptrace_exec" "$JAVA_EXE" "${{JAVA_ARGS[@]}}"
+fi
+
+exec "$JAVA_EXE" "${{JAVA_ARGS[@]}}"
+"""
+        )
+        .replace("__YSM262_JVM_ARRAY_LINES__", jvm_array_lines)
+        .replace("__YSM262_GAME_ARRAY_LINES__", game_array_lines_rendered)
+    )
+    replay_script_path = scripts_dir / "run_forgeclient_replay.sh"
+    replay_script_path.write_text(replay_script, encoding="utf-8")
+    os.chmod(replay_script_path, 0o755)
+
+    attach_script = textwrap.dedent(
+        """\
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+PID_FILE="${1:-${YSM262_PID_FILE:-$ROOT/runtime/forgeclient_replay.pid}}"
+EXTRA_GDB_SCRIPT="${2:-}"
+
+wait_for_pid_file() {
+  while [[ ! -s "$PID_FILE" ]]; do
+    sleep 0.05
+  done
+}
+
+process_ready() {
+  local pid="$1"
+  local cmdline
+  [[ -r "/proc/$pid/cmdline" ]] || return 1
+  cmdline=$(tr '\0' '\n' < "/proc/$pid/cmdline" 2>/dev/null || true)
+  if printf '%s\n' "$cmdline" | grep -Eq 'cpw\\.mods\\.bootstraplauncher\\.BootstrapLauncher|forgeclient|ysm262_ptrace_exec'; then
+    return 0
+  fi
+  local exe
+  exe=$(readlink -f "/proc/$pid/exe" 2>/dev/null || true)
+  [[ "${exe##*/}" == "java" || "${exe##*/}" == "ysm262_ptrace_exec" ]]
+}
+
+wait_for_exec_target() {
+  local pid="$1"
+  while kill -0 "$pid" 2>/dev/null; do
+    if process_ready "$pid"; then
+      return 0
+    fi
+    sleep 0.05
+  done
+  return 1
+}
+
+wait_for_pid_file
+PID=$(tr -d '[:space:]' < "$PID_FILE")
+if [[ -z "$PID" ]]; then
+  echo "pid file is empty: $PID_FILE" >&2
+  exit 1
+fi
+if ! wait_for_exec_target "$PID"; then
+  echo "process died before becoming the replay java target: $PID" >&2
+  exit 1
+fi
+
+GDB_ARGS=(
+  -q
+  -ex "set pagination off"
+  -ex "set confirm off"
+  -ex "handle SIGPIPE nostop noprint pass"
+  -ex "handle SIGSTOP nostop noprint nopass"
+  -ex "handle SIGXCPU nostop noprint pass"
+  -ex "handle SIG33 nostop noprint pass"
+)
+if [[ -n "$EXTRA_GDB_SCRIPT" ]]; then
+  GDB_ARGS+=(-ex "source $EXTRA_GDB_SCRIPT")
+fi
+GDB_ARGS+=(-ex "attach $PID" -ex c -ex c)
+
+exec gdb "${GDB_ARGS[@]}"
+"""
+    )
+    attach_script_path = scripts_dir / "attach_forgeclient_replay_pid.sh"
+    attach_script_path.write_text(attach_script, encoding="utf-8")
+    os.chmod(attach_script_path, 0o755)
+
+    return {
+        "manifest_path": str(manifest_path),
+        "session_env_example": str(env_example),
+        "session_env": str(env_runtime),
+        "replay_script": str(replay_script_path),
+        "attach_script": str(attach_script_path),
+        "captured_launch_target": command.launch_target,
+    }
+
+
+def _resolve_forge_bootstrap_info(minecraft_root: Path, *, version_id: str) -> ForgeBootstrapInfo:
+    _, manifest = _load_version_manifest(minecraft_root, version_id)
+    game_args = manifest.get("arguments", {}).get("game", [])
+    jvm_args = manifest.get("arguments", {}).get("jvm", [])
+    minecraft_version = _extract_argument_value(game_args, "--fml.mcVersion") or version_id.partition("-forge-")[0] or version_id
+    forge_version = _extract_argument_value(game_args, "--fml.forgeVersion") or (version_id.partition("-forge-")[2] or None)
+    mcp_version = _extract_argument_value(game_args, "--fml.mcpVersion") or DEFAULT_FORGE_MCP_VERSION
+    ignore_list = _find_jvm_property(jvm_args, "ignoreList") or DEFAULT_BOOTSTRAP_IGNORE_LIST_TEMPLATE.format(version_id=version_id)
+    return ForgeBootstrapInfo(
+        main_class=manifest.get("mainClass"),
+        minecraft_version=minecraft_version,
+        forge_version=forge_version,
+        mcp_version=mcp_version,
+        ignore_list=ignore_list.replace("${version_name}", version_id),
+    )
+
+
+def _collect_runtime_audit(
+    minecraft_root: Path,
+    *,
+    version_id: str,
+    fallback_roots: Sequence[Path] = DEFAULT_FALLBACK_ROOTS,
+) -> RuntimeAudit:
+    manifests: list[tuple[str, dict[str, Any]]] = []
+    current_id = version_id
+    seen: set[str] = set()
+    bootstrap_info = _resolve_forge_bootstrap_info(minecraft_root, version_id=version_id)
+    while current_id and current_id not in seen:
+        seen.add(current_id)
+        _, manifest = _load_version_manifest(minecraft_root, current_id)
+        manifests.append((current_id, manifest))
+        current_id = manifest.get("inheritsFrom")
+
+    manifests.reverse()
+    entries: list[RuntimeClasspathEntry] = []
+    missing: list[dict[str, Any]] = []
+    seen_bundle_paths: set[Path] = set()
+    main_class = None
+
+    def add_entry(
+        *,
+        manifest_version_id: str,
+        kind: str,
+        source_path: Path,
+        bundle_path: Path,
+        logical_name: str,
+    ) -> None:
+        if bundle_path in seen_bundle_paths:
+            return
+        seen_bundle_paths.add(bundle_path)
+        entries.append(
+            RuntimeClasspathEntry(
+                version_id=manifest_version_id,
+                kind=kind,
+                source_path=source_path,
+                bundle_path=bundle_path,
+                logical_name=logical_name,
+            )
+        )
+
+    for manifest_version_id, manifest in manifests:
+        main_class = manifest.get("mainClass") or main_class
+        for library in manifest.get("libraries", []):
+            if not _rules_allow(library):
+                continue
+            artifact = library.get("downloads", {}).get("artifact")
+            if not artifact:
+                continue
+            relative_path = artifact.get("path")
+            if not relative_path:
+                continue
+            source_path = minecraft_root / "libraries" / relative_path
+            source_origin = "minecraft"
+            if not source_path.is_file():
+                fallback = _find_fallback_artifact(relative_path, fallback_roots)
+                if fallback is None:
+                    missing.append(
+                        {
+                            "version_id": manifest_version_id,
+                            "kind": "library",
+                            "logical_name": library.get("name"),
+                            "relative_path": relative_path,
+                        }
+                    )
+                    continue
+                source_path = fallback
+                source_origin = "fallback"
+
+            bundle_path = Path("runtime") / "libraries" / relative_path
+            logical_name = f"{library.get('name')} [{source_origin}]"
+            add_entry(
+                manifest_version_id=manifest_version_id,
+                kind="library",
+                source_path=source_path,
+                bundle_path=bundle_path,
+                logical_name=logical_name,
+            )
+
+        version_jar = minecraft_root / "versions" / manifest_version_id / f"{manifest_version_id}.jar"
+        if version_jar.is_file():
+            bundle_path = Path("runtime") / "versions" / manifest_version_id / version_jar.name
+            add_entry(
+                manifest_version_id=manifest_version_id,
+                kind="version_jar",
+                source_path=version_jar,
+                bundle_path=bundle_path,
+                logical_name=f"{manifest_version_id}.jar [minecraft]",
+            )
+
+    forge_artifact_version = version_id.replace("-forge-", "-")
+    forge_lib_dir = minecraft_root / "libraries" / "net" / "minecraftforge" / "forge" / forge_artifact_version
+    for suffix in ("universal", "client"):
+        forge_jar = forge_lib_dir / f"forge-{forge_artifact_version}-{suffix}.jar"
+        if forge_jar.is_file():
+            add_entry(
+                manifest_version_id=version_id,
+                kind=f"forge_{suffix}",
+                source_path=forge_jar,
+                bundle_path=Path("runtime") / "libraries" / "net" / "minecraftforge" / "forge" / forge_artifact_version / forge_jar.name,
+                logical_name=f"forge-{forge_artifact_version}-{suffix}.jar [minecraft]",
+            )
+
+    for companion in DEFAULT_FORGE_RUNTIME_COMPANIONS:
+        companion_jar = (
+            minecraft_root
+            / "libraries"
+            / "net"
+            / "minecraftforge"
+            / companion
+            / forge_artifact_version
+            / f"{companion}-{forge_artifact_version}.jar"
+        )
+        if companion_jar.is_file():
+            add_entry(
+                manifest_version_id=version_id,
+                kind=f"forge_companion_{companion}",
+                source_path=companion_jar,
+                bundle_path=(
+                    Path("runtime")
+                    / "libraries"
+                    / "net"
+                    / "minecraftforge"
+                    / companion
+                    / forge_artifact_version
+                    / companion_jar.name
+                ),
+                logical_name=f"net.minecraftforge:{companion}:{forge_artifact_version} [minecraft supplemental]",
+            )
+
+    if bootstrap_info.mcp_version:
+        client_artifact_version = f"{bootstrap_info.minecraft_version}-{bootstrap_info.mcp_version}"
+        client_artifact_dir = (
+            minecraft_root
+            / "libraries"
+            / "net"
+            / "minecraft"
+            / "client"
+            / client_artifact_version
+        )
+        for suffix in DEFAULT_MCP_CLIENT_ARTIFACT_SUFFIXES:
+            jar_name = f"client-{client_artifact_version}-{suffix}.jar"
+            client_jar = client_artifact_dir / jar_name
+            if client_jar.is_file():
+                add_entry(
+                    manifest_version_id=version_id,
+                    kind=f"minecraft_client_{suffix}",
+                    source_path=client_jar,
+                    bundle_path=(
+                        Path("runtime")
+                        / "libraries"
+                        / "net"
+                        / "minecraft"
+                        / "client"
+                        / client_artifact_version
+                        / jar_name
+                    ),
+                    logical_name=f"net.minecraft:client:{client_artifact_version}:{suffix} [minecraft supplemental]",
+                )
+            else:
+                missing.append(
+                    {
+                        "version_id": version_id,
+                        "kind": f"minecraft_client_{suffix}",
+                        "logical_name": f"net.minecraft:client:{client_artifact_version}:{suffix}",
+                        "relative_path": str(
+                            Path("net") / "minecraft" / "client" / client_artifact_version / jar_name
+                        ),
+                    }
+                )
+
+    return RuntimeAudit(
+        minecraft_root=minecraft_root,
+        version_id=version_id,
+        main_class=main_class,
+        minecraft_version=bootstrap_info.minecraft_version,
+        forge_version=bootstrap_info.forge_version,
+        mcp_version=bootstrap_info.mcp_version,
+        entries=tuple(entries),
+        missing=tuple(missing),
+        searched_version_ids=tuple(version_id for version_id, _ in manifests),
+    )
+
+
+def _write_runtime_bundle(out_dir: Path, audit: RuntimeAudit) -> dict[str, Any]:
+    runtime_dir = out_dir / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[str] = []
+    for entry in audit.entries:
+        target = out_dir / entry.bundle_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(entry.source_path, target)
+        copied.append(str(entry.bundle_path))
+
+    classpath_entries = [str(entry.bundle_path) for entry in audit.entries]
+    (runtime_dir / "classpath.txt").write_text("\n".join(classpath_entries) + "\n", encoding="utf-8")
+    bootstrap_launch_excluded = {
+        str(entry.bundle_path)
+        for entry in audit.entries
+        if entry.kind == "version_jar"
+        or entry.kind == "forge_client"
+        or entry.kind.startswith("minecraft_client_")
+    }
+    bootstrap_legacy_entries = [entry for entry in classpath_entries if entry not in bootstrap_launch_excluded]
+    (runtime_dir / "bootstrap_legacy_classpath.txt").write_text(
+        "\n".join(bootstrap_legacy_entries) + "\n",
+        encoding="utf-8",
+    )
+    report = {
+        "minecraft_root": str(audit.minecraft_root),
+        "version_id": audit.version_id,
+        "searched_version_ids": list(audit.searched_version_ids),
+        "main_class": audit.main_class,
+        "minecraft_version": audit.minecraft_version,
+        "forge_version": audit.forge_version,
+        "mcp_version": audit.mcp_version,
+        "bootstrap_launch_excluded_entries": sorted(bootstrap_launch_excluded),
+        "bootstrap_legacy_classpath_entries": bootstrap_legacy_entries,
+        "classpath_entries": [
+            {
+                "version_id": entry.version_id,
+                "kind": entry.kind,
+                "logical_name": entry.logical_name,
+                "source_path": str(entry.source_path),
+                "bundle_path": str(entry.bundle_path),
+            }
+            for entry in audit.entries
+        ],
+        "missing": list(audit.missing),
+    }
+    (runtime_dir / "runtime_audit.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return report
+
+
+def _find_candidate_jars_for_classes(minecraft_root: Path, class_names: Sequence[str]) -> dict[str, list[str]]:
+    search_roots = [minecraft_root / "libraries", minecraft_root / "mods"]
+    jar_paths = sorted(
+        path
+        for root in search_roots
+        if root.is_dir()
+        for path in root.rglob("*.jar")
+        if path.is_file()
+    )
+
+    wanted = {name: name.replace(".", "/") + ".class" for name in class_names}
+    results: dict[str, list[str]] = {name: [] for name in class_names}
+    for jar_path in jar_paths:
+        try:
+            with zipfile.ZipFile(jar_path) as zf:
+                names = set(zf.namelist())
+        except zipfile.BadZipFile:
+            continue
+        for class_name, entry_name in wanted.items():
+            if entry_name in names:
+                results[class_name].append(str(jar_path))
+    return results
+
+
+def audit_minecraft_runtime(
+    minecraft_root: Path,
+    *,
+    version_id: str,
+    fallback_roots: Sequence[Path] = DEFAULT_FALLBACK_ROOTS,
+    missing_classes: Sequence[str] = (),
+) -> dict[str, Any]:
+    audit = _collect_runtime_audit(minecraft_root, version_id=version_id, fallback_roots=fallback_roots)
+    result: dict[str, Any] = {
+        "minecraft_root": str(audit.minecraft_root),
+        "version_id": audit.version_id,
+        "searched_version_ids": list(audit.searched_version_ids),
+        "main_class": audit.main_class,
+        "entry_count": len(audit.entries),
+        "missing_count": len(audit.missing),
+        "missing": list(audit.missing),
+    }
+    if missing_classes:
+        result["missing_class_candidates"] = _find_candidate_jars_for_classes(minecraft_root, missing_classes)
+    return result
+
+
+def _copy_known_files(
+    export_root: Path,
+    out_dir: Path,
+    *,
+    pairs: tuple[tuple[str, str], ...],
+    copied: list[str],
+) -> None:
+    for canonical_name, relpath in pairs:
+        src = export_root / relpath
+        if not src.is_file():
+            continue
+        shutil.copy2(src, out_dir / canonical_name)
+        copied.append(canonical_name)
+
+
+def _copy_globbed(src_root: Path, out_dir: Path, pattern: str, copied: list[str]) -> None:
+    if not src_root.is_dir():
+        return
+    for src in sorted(path for path in src_root.glob(pattern) if path.is_file()):
+        shutil.copy2(src, out_dir / src.name)
+        copied.append(src.name)
+
+
+def _real_java_executable() -> Path:
+    java = shutil.which("java")
+    if java is None:
+        raise RuntimeError("could not resolve java from PATH")
+    return Path(java).resolve()
+
+
+def _java_home_from_executable(java_executable: Path) -> Path:
+    return java_executable.parent.parent
+
+
+def _replace_with_symlink(target: Path, source: Path) -> None:
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    elif target.is_dir():
+        shutil.rmtree(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(source, target)
+
+
+def _headed_debug_layout(out_dir: Path) -> HeadedDebugLayout:
+    return HeadedDebugLayout(
+        root=out_dir,
+        game_dir=out_dir / "game",
+        trace_dir=out_dir / "trace",
+        scripts_dir=out_dir / "scripts",
+        native_tools_dir=out_dir / "native_tools",
+        bin_dir=out_dir / "bin",
+    )
+
+
+def _prepare_headed_game_dir(layout: HeadedDebugLayout, minecraft_root: Path) -> None:
+    layout.root.mkdir(parents=True, exist_ok=True)
+    layout.game_dir.mkdir(parents=True, exist_ok=True)
+    layout.trace_dir.mkdir(parents=True, exist_ok=True)
+    layout.scripts_dir.mkdir(parents=True, exist_ok=True)
+    layout.native_tools_dir.mkdir(parents=True, exist_ok=True)
+    layout.bin_dir.mkdir(parents=True, exist_ok=True)
+
+    for name in ("logs", "crash-reports", "config", "saves", "screenshots", "defaultconfigs"):
+        (layout.game_dir / name).mkdir(parents=True, exist_ok=True)
+
+    for name in ("mods", "assets", "libraries", "runtime", "versions"):
+        source = minecraft_root / name
+        if source.exists():
+            _replace_with_symlink(layout.game_dir / name, source)
+
+    options_src = minecraft_root / "options.txt"
+    if options_src.is_file():
+        shutil.copy2(options_src, layout.game_dir / "options.txt")
+
+
+def _copy_headed_host_assets(out_dir: Path) -> list[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    vm_debug_dir = repo_root / "vm_debug"
+    copied: list[str] = []
+
+    intercept_src = vm_debug_dir / "ysm262_intercept.c"
+    if intercept_src.is_file():
+        target = out_dir / "native_tools" / intercept_src.name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(intercept_src, target)
+        copied.append(str(target.relative_to(out_dir)))
+
+    return copied
+
+
+def _build_headed_interposer(layout: HeadedDebugLayout) -> Path:
+    java_executable = _real_java_executable()
+    java_home = _java_home_from_executable(java_executable)
+    source = layout.native_tools_dir / "ysm262_intercept.c"
+    target = layout.native_tools_dir / "libysm262_intercept.so"
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    subprocess.run(
+        [
+            "cc",
+            "-shared",
+            "-fPIC",
+            "-O0",
+            "-g",
+            str(source),
+            "-I",
+            str(java_home / "include"),
+            "-I",
+            str(java_home / "include" / "linux"),
+            "-pthread",
+            "-ldl",
+            "-o",
+            str(target),
+        ],
+        check=True,
+    )
+    return target
+
+
+def _default_source_profile_id(launcher_profiles: dict[str, Any], version_id: str) -> str | None:
+    profiles = launcher_profiles.get("profiles", {})
+    if "forge" in profiles:
+        return "forge"
+    for profile_id, profile in profiles.items():
+        if profile.get("lastVersionId") == version_id:
+            return profile_id
+    return None
+
+
+def _write_headed_java_wrapper(
+    layout: HeadedDebugLayout,
+    *,
+    real_java: Path,
+    interposer_path: Path,
+    model_trace: HeadedModelTraceConfig | None = None,
+) -> Path:
+    java_home = _java_home_from_executable(real_java)
+    model_trace = model_trace or HeadedModelTraceConfig()
+    default_model_trace = "1" if model_trace.enabled else "0"
+    default_model_sample = shlex.quote(model_trace.sample_hint or "")
+    default_model_families = shlex.quote(",".join(model_trace.family_filter))
+    default_model_export_filter = shlex.quote(model_trace.export_filter)
+    wrapper = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        ROOT=$(cd "$(dirname "${{BASH_SOURCE[0]}}")/.." && pwd)
+        TRACE_DIR="$ROOT/trace"
+        REAL_JAVA="{real_java}"
+        INTERPOSER="{interposer_path}"
+        JAVA_HOME_DIR="{java_home}"
+        DEFAULT_MODEL_TRACE="{default_model_trace}"
+        DEFAULT_MODEL_SAMPLE={default_model_sample}
+        DEFAULT_MODEL_FAMILIES={default_model_families}
+        DEFAULT_MODEL_EXPORT_FILTER={default_model_export_filter}
+        DEFAULT_VTABLE_REL="0x4d4140"
+        DEFAULT_VTABLE_PATCH_LEN="17"
+        DEFAULT_VTABLE_LIMIT="1"
+
+        mkdir -p "$TRACE_DIR"
+
+        {{
+          printf 'cwd=%s\\n' "$PWD"
+          printf 'real_java=%s\\n' "$REAL_JAVA"
+          printf 'arg_count=%s\\n' "$#"
+          idx=0
+          for arg in "$@"; do
+            printf 'argv[%s]=%q\\n' "$idx" "$arg"
+            idx=$((idx + 1))
+          done
+        }} >> "${{YSM262_WRAPPER_ARGV_LOG:-$TRACE_DIR/java_wrapper_argv.log}}"
+
+        env | sort > "${{YSM262_WRAPPER_ENV_LOG:-$TRACE_DIR/java_wrapper_env.log}}"
+
+        export LD_PRELOAD="$INTERPOSER${{LD_PRELOAD:+:$LD_PRELOAD}}"
+        export YSM262_INTERCEPT_LOG="${{YSM262_INTERCEPT_LOG:-$TRACE_DIR/ysm262_intercept.log}}"
+        export YSM262_SPOOF_PROC_SELF_EXE="${{YSM262_SPOOF_PROC_SELF_EXE:-$REAL_JAVA}}"
+        export YSM262_SPOOF_DLADDR_LIBJVM="${{YSM262_SPOOF_DLADDR_LIBJVM:-$JAVA_HOME_DIR/lib/server/libjvm.so}}"
+        export YSM262_SPOOF_DLADDR_JVM_ORIGINS="${{YSM262_SPOOF_DLADDR_JVM_ORIGINS:-1}}"
+        export YSM262_SPOOF_PRCTL_VM="${{YSM262_SPOOF_PRCTL_VM:-1}}"
+        export YSM262_SPOOF_HOSTNAME="${{YSM262_SPOOF_HOSTNAME:-localhost}}"
+        export YSM262_SPOOF_AFFINITY_ONECPU="${{YSM262_SPOOF_AFFINITY_ONECPU:-1}}"
+        export YSM262_TRACE_JNI_ENV="${{YSM262_TRACE_JNI_ENV:-0}}"
+        export YSM262_TRACE_CACHE_IO="${{YSM262_TRACE_CACHE_IO:-1}}"
+        export YSM262_TRACE_CACHE_BT="${{YSM262_TRACE_CACHE_BT:-1}}"
+        export YSM262_TRACE_CACHE_BT_FILTER="${{YSM262_TRACE_CACHE_BT_FILTER:-custom,server_index,server}}"
+        export YSM262_TRACE_CACHE_BT_EVENTS="${{YSM262_TRACE_CACHE_BT_EVENTS:-fopen,openat,read,pread,pread64}}"
+        export YSM262_TRACE_CACHE_BT_LIMIT="${{YSM262_TRACE_CACHE_BT_LIMIT:-24}}"
+        export YSM262_TRACE_VTABLE_WORDS="${{YSM262_TRACE_VTABLE_WORDS:-4}}"
+        export YSM262_TRACE_VTABLE_FIELD_CANDIDATES="${{YSM262_TRACE_VTABLE_FIELD_CANDIDATES:-4}}"
+        export YSM262_TRACE_VTABLE_NESTED_WORDS="${{YSM262_TRACE_VTABLE_NESTED_WORDS:-4}}"
+        export YSM262_TRACE_CHILD_VTABLE_REL="${{YSM262_TRACE_CHILD_VTABLE_REL:-0xd2b2b0}}"
+        export YSM262_TRACE_CHILD_FOLLOW_OFFSET="${{YSM262_TRACE_CHILD_FOLLOW_OFFSET:-0x8090}}"
+        export YSM262_TRACE_CHILD_FOLLOW_QWORD_INDEX="${{YSM262_TRACE_CHILD_FOLLOW_QWORD_INDEX:-0}}"
+        export YSM262_TRACE_CHILD_FOLLOW_QWORD_DEPTH="${{YSM262_TRACE_CHILD_FOLLOW_QWORD_DEPTH:-3}}"
+        export YSM262_TRACE_MODEL="${{YSM262_TRACE_MODEL:-$DEFAULT_MODEL_TRACE}}"
+        export YSM262_TRACE_MODEL_SAMPLE="${{YSM262_TRACE_MODEL_SAMPLE:-$DEFAULT_MODEL_SAMPLE}}"
+        export YSM262_TRACE_MODEL_FAMILIES="${{YSM262_TRACE_MODEL_FAMILIES:-$DEFAULT_MODEL_FAMILIES}}"
+        export YSM262_TRACE_MODEL_EXPORT_FILTER="${{YSM262_TRACE_MODEL_EXPORT_FILTER:-$DEFAULT_MODEL_EXPORT_FILTER}}"
+        export YSM262_TRACE_MODEL_REL="${{YSM262_TRACE_MODEL_REL:-0x{model_trace.trace_rel:x}}}"
+        export YSM262_TRACE_MODEL_PATCH_LEN="${{YSM262_TRACE_MODEL_PATCH_LEN:-{model_trace.patch_len}}}"
+        export YSM262_TRACE_MODEL_LIMIT="${{YSM262_TRACE_MODEL_LIMIT:-{model_trace.budget}}}"
+        export YSM262_TRACE_MODEL_SCAN_BYTES="${{YSM262_TRACE_MODEL_SCAN_BYTES:-0x{model_trace.scan_bytes:x}}}"
+        export YSM262_TRACE_MODEL_STRING_LIMIT="${{YSM262_TRACE_MODEL_STRING_LIMIT:-{model_trace.string_limit}}}"
+        export YSM262_TRACE_MODEL_VECTOR_LIMIT="${{YSM262_TRACE_MODEL_VECTOR_LIMIT:-{model_trace.vector_limit}}}"
+
+        if [[ "$YSM262_TRACE_MODEL" != "0" && "$YSM262_TRACE_MODEL" != "false" ]]; then
+          DEFAULT_VTABLE_REL="$YSM262_TRACE_MODEL_REL"
+          DEFAULT_VTABLE_PATCH_LEN="$YSM262_TRACE_MODEL_PATCH_LEN"
+          DEFAULT_VTABLE_LIMIT="$YSM262_TRACE_MODEL_LIMIT"
+        fi
+        export YSM262_TRACE_VTABLE_DUMP="${{YSM262_TRACE_VTABLE_DUMP:-1}}"
+        export YSM262_TRACE_VTABLE_REL="${{YSM262_TRACE_VTABLE_REL:-$DEFAULT_VTABLE_REL}}"
+        export YSM262_TRACE_VTABLE_PATCH_LEN="${{YSM262_TRACE_VTABLE_PATCH_LEN:-$DEFAULT_VTABLE_PATCH_LEN}}"
+        export YSM262_TRACE_VTABLE_LIMIT="${{YSM262_TRACE_VTABLE_LIMIT:-$DEFAULT_VTABLE_LIMIT}}"
+
+        exec "$REAL_JAVA" "$@"
+        """
+    )
+    target = layout.bin_dir / "java_wrapper.sh"
+    target.write_text(wrapper, encoding="utf-8")
+    os.chmod(target, 0o755)
+    return target
+
+
+def _write_headed_profile_payload(
+    out_dir: Path,
+    *,
+    profile_id: str,
+    profile_name: str,
+    version_id: str,
+    game_dir: Path,
+    java_wrapper: Path,
+    source_profile_id: str | None,
+) -> Path:
+    payload = {
+        "profile_id": profile_id,
+        "profile_name": profile_name,
+        "version_id": version_id,
+        "game_dir": str(game_dir),
+        "java_dir": str(java_wrapper),
+        "source_profile_id": source_profile_id,
+        "icon": "Grass",
+        "type": "custom",
+    }
+    target = out_dir / "launcher_profile_payload.json"
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return target
+
+
+def _write_headed_profile_installer(out_dir: Path) -> Path:
+    scripts_dir = out_dir / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    script = textwrap.dedent(
+        """\
+        #!/usr/bin/env python3
+        from __future__ import annotations
+
+        import argparse
+        import json
+        import shutil
+        from pathlib import Path
+
+
+        def choose_source_profile(profiles: dict[str, dict], payload: dict, explicit: str | None) -> tuple[str | None, dict]:
+            if explicit and explicit in profiles:
+                return explicit, dict(profiles[explicit])
+            source_from_payload = payload.get("source_profile_id")
+            if source_from_payload and source_from_payload in profiles:
+                return source_from_payload, dict(profiles[source_from_payload])
+            if "forge" in profiles:
+                return "forge", dict(profiles["forge"])
+            for profile_id, profile in profiles.items():
+                if profile.get("lastVersionId") == payload["version_id"]:
+                    return profile_id, dict(profile)
+            return None, {}
+
+
+        def main() -> int:
+            root = Path(__file__).resolve().parents[1]
+            payload = json.loads((root / "launcher_profile_payload.json").read_text(encoding="utf-8"))
+
+            ap = argparse.ArgumentParser(description="Install the staged YSM headed-debug launcher profile.")
+            ap.add_argument(
+                "--launcher-profiles",
+                type=Path,
+                default=Path.home() / ".minecraft" / "launcher_profiles.json",
+                help="launcher_profiles.json to update",
+            )
+            ap.add_argument("--profile-id", default=payload["profile_id"], help="profile id to create/update")
+            ap.add_argument("--profile-name", default=payload["profile_name"], help="profile display name")
+            ap.add_argument("--source-profile-id", help="existing profile id to copy javaArgs/icon defaults from")
+            ap.add_argument("--dry-run", action="store_true", help="print the final profile JSON without writing")
+            args = ap.parse_args()
+
+            launcher_profiles = args.launcher_profiles
+            data = json.loads(launcher_profiles.read_text(encoding="utf-8"))
+            profiles = data.setdefault("profiles", {})
+            source_profile_id, profile = choose_source_profile(profiles, payload, args.source_profile_id)
+
+            profile.update(
+                {
+                    "name": args.profile_name,
+                    "lastVersionId": payload["version_id"],
+                    "gameDir": payload["game_dir"],
+                    "javaDir": payload["java_dir"],
+                    "type": payload.get("type", "custom"),
+                    "icon": profile.get("icon", payload.get("icon", "Grass")),
+                }
+            )
+
+            if args.dry_run:
+                print(json.dumps(profile, indent=2))
+                return 0
+
+            backup = launcher_profiles.with_name(launcher_profiles.name + ".ysm262.backup")
+            shutil.copy2(launcher_profiles, backup)
+            profiles[args.profile_id] = profile
+            launcher_profiles.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            print(f"updated_profile={args.profile_id}")
+            print(f"backup={backup}")
+            print(f"source_profile={source_profile_id}")
+            return 0
+
+
+        if __name__ == "__main__":
+            raise SystemExit(main())
+        """
+    )
+    target = scripts_dir / "install_launcher_profile.py"
+    target.write_text(script, encoding="utf-8")
+    os.chmod(target, 0o755)
+    return target
+
+
+def _write_headed_host_readme(
+    out_dir: Path,
+    *,
+    version_id: str,
+    minecraft_root: Path,
+    profile_name: str,
+    model_trace: HeadedModelTraceConfig | None = None,
+) -> None:
+    model_trace = model_trace or HeadedModelTraceConfig()
+    model_trace_notes = ""
+    if model_trace.enabled:
+        family_text = ", ".join(model_trace.family_filter) if model_trace.family_filter else "(all discovered bone-name candidates)"
+        model_trace_notes = textwrap.dedent(
+            f"""\
+            
+            Model trace defaults in this bundle:
+            - `YSM262_TRACE_MODEL=1`
+            - `YSM262_TRACE_MODEL_SAMPLE={model_trace.sample_hint or '(auto from staged sample path)'}`
+            - `YSM262_TRACE_MODEL_FAMILIES={family_text}`
+            - `YSM262_TRACE_MODEL_EXPORT_FILTER={model_trace.export_filter}`
+            - `YSM262_TRACE_MODEL_REL=0x{model_trace.trace_rel:x}`
+            - `YSM262_TRACE_MODEL_PATCH_LEN={model_trace.patch_len}`
+            - `YSM262_TRACE_MODEL_LIMIT={model_trace.budget}`
+            - `YSM262_TRACE_MODEL_SCAN_BYTES=0x{model_trace.scan_bytes:x}`
+            
+            Suggested post-run summary:
+            - `python3 ysm262_oracle.py summarize-model-trace trace/ysm262_intercept.log --json`
+            - if you later obtain a matching snapshot: `python3 ysm262_oracle.py summarize-model-trace trace/ysm262_intercept.log --snapshot-root official_export_snapshot --json`
+            """
+        )
+    text = textwrap.dedent(
+        f"""\
+        # YSM Headed Host Debug Bundle
+
+        Purpose:
+        - compatibility and porting research for Yes Steve Model legacy decoding
+        - authentic native/debug tracing against the real Forge client shape
+        - not malware development
+
+        This bundle does not try to preserve the synthetic VM-only `err: 56` path.
+        It is for running the real local Forge profile under an isolated `gameDir`
+        while keeping the launcher-owned runtime roots from `{minecraft_root}`.
+
+        Included:
+        - `game/`
+        - `bin/java_wrapper.sh`
+        - `native_tools/ysm262_intercept.c`
+        - `native_tools/libysm262_intercept.so`
+        - `launcher_profile_payload.json`
+        - `scripts/install_launcher_profile.py`
+        - `headed_host_manifest.json`
+
+        Suggested first use:
+        1. `python3 scripts/install_launcher_profile.py`
+        2. Launch the `{profile_name}` profile from the official launcher.
+        3. Inspect:
+           - `trace/java_wrapper_argv.log`
+           - `trace/java_wrapper_env.log`
+           - `trace/ysm262_intercept.log`
+           - `game/logs/latest.log`
+           - `game/logs/debug.log`
+
+        Important notes:
+        - default repo-local runtime-debug root is `ROOT/debug_runtime`; override with `{DEFAULT_DEBUG_RUNTIME_ENV}`
+        - the canonical headed-host bundle path is `ROOT/debug_runtime/headed_host_bundle`
+        - treat this headed bundle as a corroboration/control lane, not the primary live debugger
+        - the primary live-debug path is now the guest-side `stage-vm` bootstrap harness under `gdb`
+        - host-side `gdb` is still not the primary tool for this ELF
+        - `YSM262_TRACE_JNI_ENV` defaults to `0` in the Java wrapper to preserve the authentic host path
+        - if the process later dies with `SIGKILL` plus a `zenity` dialog, treat that as the separate anti-debug branch
+        {model_trace_notes}
+        """
+    )
+    (out_dir / "README.md").write_text(text, encoding="utf-8")
+
+
+def stage_headed_host_bundle(
+    out_dir: Path | None,
+    *,
+    minecraft_root: Path = DEFAULT_MINECRAFT_ROOT,
+    version_id: str = DEFAULT_FORGE_VERSION_ID,
+    launcher_profiles: Path | None = None,
+    profile_id: str = DEFAULT_HEADED_DEBUG_PROFILE_ID,
+    profile_name: str = DEFAULT_HEADED_DEBUG_PROFILE_NAME,
+    model_trace: HeadedModelTraceConfig | None = None,
+) -> Path:
+    out_dir = (out_dir or _default_headed_host_out_dir()).resolve()
+    launcher_profiles = launcher_profiles or (minecraft_root / "launcher_profiles.json")
+    model_trace = model_trace or HeadedModelTraceConfig()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    layout = _headed_debug_layout(out_dir)
+    _prepare_headed_game_dir(layout, minecraft_root)
+    copied_assets = _copy_headed_host_assets(out_dir)
+    interposer_path = _build_headed_interposer(layout)
+    real_java = _real_java_executable()
+    java_wrapper = _write_headed_java_wrapper(
+        layout,
+        real_java=real_java,
+        interposer_path=interposer_path,
+        model_trace=model_trace,
+    )
+
+    source_profile_id = None
+    if launcher_profiles.is_file():
+        launcher_state = json.loads(launcher_profiles.read_text(encoding="utf-8"))
+        source_profile_id = _default_source_profile_id(launcher_state, version_id)
+
+    payload_path = _write_headed_profile_payload(
+        out_dir,
+        profile_id=profile_id,
+        profile_name=profile_name,
+        version_id=version_id,
+        game_dir=layout.game_dir,
+        java_wrapper=java_wrapper,
+        source_profile_id=source_profile_id,
+    )
+    installer_path = _write_headed_profile_installer(out_dir)
+    _write_headed_host_readme(
+        out_dir,
+        version_id=version_id,
+        minecraft_root=minecraft_root,
+        profile_name=profile_name,
+        model_trace=model_trace,
+    )
+
+    manifest = {
+        "purpose": (
+            "Compatibility and porting research for Yes Steve Model legacy decoding. "
+            "This headed-host bundle is for benign reverse-engineering and verification, not malware development."
+        ),
+        "minecraft_root": str(minecraft_root),
+        "version_id": version_id,
+        "launcher_profiles": str(launcher_profiles),
+        "profile_id": profile_id,
+        "profile_name": profile_name,
+        "source_profile_id": source_profile_id,
+        "game_dir": str(layout.game_dir),
+        "trace_dir": str(layout.trace_dir),
+        "real_java": str(real_java),
+        "java_wrapper": str(java_wrapper),
+        "interposer": str(interposer_path),
+        "payload": str(payload_path),
+        "installer": str(installer_path),
+        "model_trace": {
+            "enabled": model_trace.enabled,
+            "sample_hint": model_trace.sample_hint,
+            "family_filter": list(model_trace.family_filter),
+            "export_filter": model_trace.export_filter,
+            "trace_rel": hex(model_trace.trace_rel),
+            "patch_len": model_trace.patch_len,
+            "budget": model_trace.budget,
+            "scan_bytes": hex(model_trace.scan_bytes),
+            "string_limit": model_trace.string_limit,
+            "vector_limit": model_trace.vector_limit,
+        },
+        "copied_assets": copied_assets,
+        "symlinked_game_entries": sorted(
+            path.name
+            for path in layout.game_dir.iterdir()
+            if path.is_symlink()
+        ),
+    }
+    (out_dir / "headed_host_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return out_dir
+
+
+def _write_legacy_capture_readme(
+    capture: LegacyExportCapture,
+    *,
+    ysm_path: Path,
+    model_id: str,
+    suggested_command: str | None,
+    source_root: Path | None,
+    snapshot_ready: bool,
+    model_trace: HeadedModelTraceConfig | None,
+    trace_only: bool,
+) -> None:
+    model_trace = model_trace or HeadedModelTraceConfig()
+    status_line = (
+        f"- latest canonical snapshot: `{capture.snapshot_root}`"
+        if snapshot_ready
+        else "- no official export payload detected yet under the raw export root"
+    )
+    if snapshot_ready:
+        verify_line = (
+            f"- recommended verifier command after snapshot: `python3 verify_legacy_pair.py {ysm_path} --source-root {source_root} --official-export-root {capture.snapshot_root}`"
+            if source_root is not None
+            else f"- if you later choose a paired source tree manually: `python3 verify_legacy_pair.py {ysm_path} --source-root <source-tree> --official-export-root {capture.snapshot_root}`"
+        )
+    else:
+        verify_line = "- verifier step is pending until a snapshot or other truth asset exists"
+    model_trace_lines = ""
+    if model_trace.enabled:
+        model_trace_lines = textwrap.dedent(
+            f"""\
+            - model trace is enabled in the staged Java wrapper
+            - sample filter: `{model_trace.sample_hint or ysm_path.name}`
+            - export filter: `{model_trace.export_filter}`
+            - trace rel: `0x{model_trace.trace_rel:x}`
+            - after a run, summarize the trace with:
+              `python3 ysm262_oracle.py summarize-model-trace {capture.bundle_root / "trace" / "ysm262_intercept.log"} --family-filter {",".join(model_trace.family_filter) if model_trace.family_filter else "<families>"} --json`
+            - if you later obtain a matching snapshot, join it with:
+              `python3 ysm262_oracle.py summarize-model-trace {capture.bundle_root / "trace" / "ysm262_intercept.log"} --snapshot-root {capture.snapshot_root} --json`
+            """
+        )
+    in_game_flow = textwrap.dedent(
+        f"""\
+        In-game flow:
+        1. `python3 {capture.bundle_root / "scripts" / "install_launcher_profile.py"}`
+        2. Launch the staged profile from the official launcher.
+        3. Join a world so YSM ingests the staged `custom/*.ysm` sample.
+        4. Quit the game after the sample has clearly loaded.
+        5. Inspect `{capture.bundle_root / "trace" / "ysm262_intercept.log"}` and run the trace summarizer.
+        """
+    )
+    if not trace_only:
+        command_line = suggested_command or "/ysm export <model_id>"
+        in_game_flow = textwrap.dedent(
+            f"""\
+            In-game flow:
+            1. `python3 {capture.bundle_root / "scripts" / "install_launcher_profile.py"}`
+            2. Launch the staged profile from the official launcher.
+            3. Join a world so YSM ingests the staged `custom/*.ysm` sample.
+            4. Run:
+               - `{command_line}`
+            5. Quit the game, then rerun the same capture command to harvest the export into a canonical snapshot.
+            """
+        )
+    notes = textwrap.dedent(
+        """\
+        Notes:
+        - this capture helper stages the sample and harvests outputs when they exist; it does not try to automate the GUI/client session itself
+        """
+    )
+    if not trace_only:
+        notes += textwrap.dedent(
+            """\
+            - the official command root is `/ysm`
+            - the export subcommand shape recovered from the jar is `/ysm export <model_id> [extra]`
+            """
+        )
+    text = textwrap.dedent(
+        f"""\
+        # Legacy Export Capture
+
+        Purpose:
+        - use the real YSM `2.6.2` headed client/native export path as the truth lane for legacy formats
+        - not heuristic Python reconstruction
+
+        Sample:
+        - source sample: `{ysm_path}`
+        - staged custom pack: `{capture.sample_copy}`
+        - imported model id: `{model_id}`
+
+        Live paths:
+        - headed bundle root: `{capture.bundle_root}`
+        - custom input root: `{capture.custom_dir}`
+        - raw official export root: `{capture.export_root}`
+        {status_line}
+
+        {in_game_flow}
+        {notes}
+        {model_trace_lines}
+        {verify_line}
+        """
+    )
+    (capture.bundle_root / "legacy_export_capture_README.md").write_text(text, encoding="utf-8")
+
+
+def capture_legacy_export(
+    ysm_path: Path,
+    *,
+    out_dir: Path | None = None,
+    minecraft_root: Path = DEFAULT_MINECRAFT_ROOT,
+    version_id: str = DEFAULT_FORGE_VERSION_ID,
+    launcher_profiles: Path | None = None,
+    profile_id: str | None = None,
+    profile_name: str | None = None,
+    model_id: str | None = None,
+    extra: str | None = None,
+    export_root: Path | None = None,
+    snapshot_dir: Path | None = None,
+    keep_existing: bool = False,
+    model_trace: HeadedModelTraceConfig | None = None,
+    trace_only: bool = False,
+) -> LegacyExportCapture:
+    ysm_path = ysm_path.resolve()
+    if not ysm_path.is_file():
+        raise FileNotFoundError(ysm_path)
+
+    out_dir = (out_dir or _default_capture_out_dir(ysm_path)).resolve()
+    model_trace = model_trace or HeadedModelTraceConfig()
+    default_profile_id, default_profile_name = _default_capture_profile_identity(
+        ysm_path,
+        out_dir=out_dir,
+        model_trace=model_trace,
+    )
+    profile_id = profile_id or default_profile_id
+    profile_name = profile_name or default_profile_name
+    model_id = model_id or ysm_path.stem
+    if model_trace.enabled and model_trace.sample_hint is None:
+        model_trace = HeadedModelTraceConfig(
+            enabled=True,
+            sample_hint=ysm_path.name,
+            family_filter=model_trace.family_filter,
+            export_filter=model_trace.export_filter,
+            trace_rel=model_trace.trace_rel,
+            patch_len=model_trace.patch_len,
+            budget=model_trace.budget,
+            scan_bytes=model_trace.scan_bytes,
+            string_limit=model_trace.string_limit,
+            vector_limit=model_trace.vector_limit,
+        )
+    launcher_profiles = launcher_profiles or (minecraft_root / "launcher_profiles.json")
+
+    stage_headed_host_bundle(
+        out_dir,
+        minecraft_root=minecraft_root,
+        version_id=version_id,
+        launcher_profiles=launcher_profiles,
+        profile_id=profile_id,
+        profile_name=profile_name,
+        model_trace=model_trace,
+    )
+
+    layout = _headed_debug_layout(out_dir)
+    ysm_root = layout.game_dir / "config" / "yes_steve_model"
+    custom_dir = ysm_root / "custom"
+    export_root = (export_root or (ysm_root / "export")).resolve()
+    snapshot_dir = (snapshot_dir or (out_dir / "official_export_snapshot")).resolve()
+    manifest_path = out_dir / "legacy_export_capture.json"
+    capture = LegacyExportCapture(
+        bundle_root=out_dir,
+        custom_dir=custom_dir,
+        export_root=export_root,
+        sample_copy=custom_dir / ysm_path.name,
+        snapshot_root=snapshot_dir,
+        manifest_path=manifest_path,
+    )
+
+    custom_dir.mkdir(parents=True, exist_ok=True)
+    export_root.mkdir(parents=True, exist_ok=True)
+    existing_candidates = _candidate_export_roots(export_root)
+    previous_manifest: dict[str, Any] | None = None
+    if manifest_path.is_file():
+        try:
+            previous_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            previous_manifest = None
+    same_sample_as_previous = (
+        previous_manifest is not None
+        and previous_manifest.get("ysm_path") == str(ysm_path)
+        and previous_manifest.get("model_id") == model_id
+    )
+    reuse_existing_export = bool(existing_candidates) and (keep_existing or same_sample_as_previous)
+    if not keep_existing and not reuse_existing_export:
+        _clear_dir_children(custom_dir)
+        _clear_dir_children(export_root)
+        if snapshot_dir.exists():
+            shutil.rmtree(snapshot_dir)
+    shutil.copy2(ysm_path, capture.sample_copy)
+
+    candidates = existing_candidates if reuse_existing_export else _candidate_export_roots(export_root)
+    selected_export_root = _select_export_root(candidates, model_id=model_id)
+    snapshot_created = False
+    if selected_export_root is not None:
+        snapshot_official_export(
+            selected_export_root,
+            out_dir=snapshot_dir,
+            ysm_path=ysm_path,
+        )
+        snapshot_created = True
+
+    baseline = probe_ysm262_official()
+    source_root, source_match_count, source_asset_count = find_best_source_oracle(ysm_path)
+    suggested_command = None
+    if not trace_only:
+        suggested_command = f"/ysm export {model_id}"
+        if extra:
+            suggested_command = f"{suggested_command} {extra}"
+
+    verify_command = None
+    if snapshot_created:
+        base = f"python3 verify_legacy_pair.py {ysm_path}"
+        if source_root is not None:
+            verify_command = f"{base} --source-root {source_root} --official-export-root {snapshot_dir}"
+        else:
+            verify_command = f"{base} --source-root <source-tree> --official-export-root {snapshot_dir}"
+
+    manifest = {
+        "purpose": (
+            "Compatibility and porting research for Yes Steve Model legacy decoding. "
+            "This capture tracks the real headed-client/native export path, not heuristic Python reconstruction."
+        ),
+        "status": (
+            "snapshot_ready"
+            if snapshot_created
+            else ("staged_waiting_for_trace" if trace_only else "staged_waiting_for_export")
+        ),
+        "ysm_path": str(ysm_path),
+        "property_name": _read_property_name(ysm_path),
+        "codec_format": _read_property_format(ysm_path),
+        "model_id": model_id,
+        "extra": extra,
+        "bundle_root": str(out_dir),
+        "profile_id": profile_id,
+        "profile_name": profile_name,
+        "game_dir": str(layout.game_dir),
+        "custom_dir": str(custom_dir),
+        "sample_copy": str(capture.sample_copy),
+        "sample_sha256": _hash_file(capture.sample_copy),
+        "raw_export_root": str(export_root),
+        "export_candidates": [str(path) for path in candidates],
+        "selected_export_root": str(selected_export_root) if selected_export_root is not None else None,
+        "official_snapshot_root": str(snapshot_dir) if snapshot_created else None,
+        "official_jar": str(baseline.jar_path) if baseline is not None else None,
+        "official_jar_sha256": baseline.jar_sha256 if baseline is not None else None,
+        "official_native_entries": list(baseline.native_entries) if baseline is not None else [],
+        "official_native_sha256": list(baseline.native_sha256) if baseline is not None else [],
+        "trace_only": trace_only,
+        "suggested_export_command": suggested_command,
+        "source_root": str(source_root) if source_root is not None else None,
+        "source_match_count": source_match_count,
+        "source_asset_count": source_asset_count,
+        "verify_command": verify_command,
+        "model_trace": {
+            "enabled": model_trace.enabled,
+            "sample_hint": model_trace.sample_hint,
+            "family_filter": list(model_trace.family_filter),
+            "export_filter": model_trace.export_filter,
+            "trace_rel": hex(model_trace.trace_rel),
+            "patch_len": model_trace.patch_len,
+            "budget": model_trace.budget,
+            "scan_bytes": hex(model_trace.scan_bytes),
+            "string_limit": model_trace.string_limit,
+            "vector_limit": model_trace.vector_limit,
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    _write_legacy_capture_readme(
+        capture,
+        ysm_path=ysm_path,
+        model_id=model_id,
+        suggested_command=suggested_command,
+        source_root=source_root,
+        snapshot_ready=snapshot_created,
+        model_trace=model_trace,
+        trace_only=trace_only,
+    )
+    return capture
+
+
+def _trace_family_matches(name: str, family_filter: Sequence[str]) -> bool:
+    if not family_filter:
+        return True
+    lower_name = name.lower()
+    for token in family_filter:
+        lowered = token.lower()
+        if lowered in lower_name or lower_name in lowered:
+            return True
+    return False
+
+
+def _load_snapshot_bones(snapshot_root: Path, model_name: str) -> list[dict[str, Any]]:
+    layout = detect_export_layout(snapshot_root)
+    rel_path = next((rel for canonical, rel in layout.model_pairs if canonical == model_name), model_name)
+    path = layout.root / rel_path
+    if not path.is_file():
+        return []
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(obj, dict):
+        return []
+    geometry = obj.get("minecraft:geometry")
+    if not isinstance(geometry, list):
+        return []
+    for item in geometry:
+        if not isinstance(item, dict):
+            continue
+        bones = item.get("bones")
+        if isinstance(bones, list):
+            return [bone for bone in bones if isinstance(bone, dict)]
+    return []
+
+
+def summarize_model_trace(
+    intercept_log: Path,
+    *,
+    snapshot_root: Path | None = None,
+    family_filter: Sequence[str] = tuple(),
+    model_name: str = "main.json",
+) -> dict[str, Any]:
+    intercept_log = intercept_log.resolve()
+    if not intercept_log.is_file():
+        raise FileNotFoundError(intercept_log)
+
+    summary: dict[str, Any] = {
+        "intercept_log": str(intercept_log),
+        "snapshot_root": str(snapshot_root.resolve()) if snapshot_root is not None else None,
+        "model_name": model_name,
+        "family_filter": list(family_filter),
+        "events": [],
+        "objects": {},
+        "bone_summaries": [],
+        "candidate_hook_rels": [],
+    }
+
+    object_hits: dict[str, dict[str, Any]] = {}
+    lines = intercept_log.read_text(encoding="utf-8", errors="replace").splitlines()
+    line_re = re.compile(r"^\[ysm262-intercept\]\s+model_trace\s+(\w+)\s+(.*)$")
+    event_re = re.compile(r"^\[ysm262-intercept\]\s+model_trace\s+event=([^ ]+)\s+(.*)$")
+    candidate_rels: dict[int, int] = {}
+    event_indexes: list[int] = []
+    for idx, raw_line in enumerate(lines):
+        stripped = raw_line.strip()
+        event_match = event_re.match(stripped)
+        if event_match is not None:
+            payload = f"event={event_match.group(1)} {event_match.group(2)}".strip()
+            summary["events"].append(payload)
+            event_indexes.append(idx)
+            continue
+        match = line_re.match(stripped)
+        if match is None:
+            continue
+        kind = match.group(1)
+        payload = match.group(2)
+        if kind == "event":
+            summary["events"].append(payload)
+            event_indexes.append(idx)
+            continue
+        label_match = re.search(r"label=([^ ]+)", payload)
+        if label_match is None:
+            continue
+        label = label_match.group(1)
+        entry = object_hits.setdefault(label, {"strings": [], "ptr_strings": [], "float3": [], "object": None})
+        if kind == "object":
+            entry["object"] = payload
+        elif kind == "string":
+            entry["strings"].append(payload)
+        elif kind == "ptr_string":
+            entry["ptr_strings"].append(payload)
+        elif kind == "float3":
+            entry["float3"].append(payload)
+
+    summary["objects"] = object_hits
+
+    for idx in event_indexes:
+        window = lines[max(0, idx - 25) : min(len(lines), idx + 45)]
+        for line in window:
+            if "libysm-core" not in line:
+                continue
+            if " caller=" not in line and " bt[" not in line:
+                continue
+            match = re.search(r"rel=0x([0-9a-fA-F]+)", line)
+            if match is None:
+                continue
+            rel = int(match.group(1), 16)
+            candidate_rels[rel] = candidate_rels.get(rel, 0) + 1
+    summary["candidate_hook_rels"] = [
+        {"rel": hex(rel), "hits": hits}
+        for rel, hits in sorted(candidate_rels.items(), key=lambda item: (-item[1], item[0]))
+    ]
+
+    if snapshot_root is not None:
+        bones = _load_snapshot_bones(snapshot_root.resolve(), model_name)
+        for bone in bones:
+            name = str(bone.get("name", ""))
+            if not name or not _trace_family_matches(name, family_filter):
+                continue
+            matching_labels = []
+            for label, payload in object_hits.items():
+                observed_names = " ".join(payload["strings"] + payload["ptr_strings"])
+                if name in observed_names:
+                    matching_labels.append(label)
+            summary["bone_summaries"].append(
+                {
+                    "name": name,
+                    "parent": bone.get("parent"),
+                    "pivot": bone.get("pivot"),
+                    "cube_count": len(bone.get("cubes", [])) if isinstance(bone.get("cubes"), list) else 0,
+                    "matching_trace_labels": matching_labels,
+                }
+            )
+
+    return summary
+
+
+def snapshot_official_export(
+    export_root: Path,
+    *,
+    out_dir: Path | None = None,
+    ysm_path: Path | None = None,
+    official_jar: Path | None = None,
+) -> Path:
+    export_root = export_root.resolve()
+    if not export_root.exists():
+        raise FileNotFoundError(export_root)
+
+    if out_dir is None:
+        stem = ysm_path.stem if ysm_path is not None else export_root.name
+        out_dir = export_root.parent / f"{stem}_official_export_snapshot"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    _clear_known_output_dir(
+        out_dir,
+        (
+            "*.json",
+            "*.png",
+            "*.ogg",
+            "official_export_snapshot.json",
+        ),
+    )
+
+    layout = detect_export_layout(export_root)
+    copied: list[str] = []
+    _copy_known_files(export_root, out_dir, pairs=layout.model_pairs, copied=copied)
+    _copy_known_files(export_root, out_dir, pairs=layout.animation_pairs, copied=copied)
+    _copy_globbed(layout.texture_root, out_dir, PNG_GLOB, copied)
+    _copy_globbed(layout.sound_root, out_dir, SOUND_GLOB, copied)
+
+    baseline = probe_ysm262_official(official_jar)
+    manifest = {
+        "purpose": (
+            "Compatibility and porting research for Yes Steve Model legacy 9/15 decoding. "
+            "This snapshot is for benign reverse-engineering and verification, not malware development."
+        ),
+        "export_root": str(export_root),
+        "snapshot_root": str(out_dir),
+        "ysm_path": str(ysm_path) if ysm_path is not None else None,
+        "codec_format": _read_property_format(ysm_path) if ysm_path is not None else None,
+        "official_jar": str(baseline.jar_path) if baseline is not None else None,
+        "official_jar_sha256": baseline.jar_sha256 if baseline is not None else None,
+        "official_native_entries": list(baseline.native_entries) if baseline is not None else [],
+        "official_native_sha256": list(baseline.native_sha256) if baseline is not None else [],
+        "official_loader_classes": list(baseline.loader_classes) if baseline is not None else [],
+        "official_export_classes": list(baseline.export_classes) if baseline is not None else [],
+        "copied_files": copied,
+    }
+    (out_dir / "official_export_snapshot.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return out_dir
+
+
+def _write_vm_bundle_readme(
+    out_dir: Path,
+    *,
+    jar_name: str,
+    linux_native_name: str | None,
+    sample_paths: Sequence[Path],
+    launcher_replay: dict[str, Any] | None = None,
+) -> None:
+    samples_rendered = "\n".join(f"- `{path}`" for path in sample_paths) if sample_paths else "- none staged"
+    java_run = (
+        "gdb --args java -cp build YsmNativeStartupGateProbe "
+        f"--jar official/{jar_name} --lib native/{linux_native_name} --pause-before-call-ms 3000"
+        if linux_native_name is not None
+        else "gdb --args java -cp build YsmNativeStartupGateProbe --jar official/<jar> --lib native/<libysm-core.so>"
+    )
+    replay_contents = ""
+    replay_steps = ""
+    if launcher_replay:
+        replay_contents = textwrap.dedent(
+            """\
+            - `runtime/forgeclient_replay_manifest.json`
+            - `runtime/forgeclient_session.env`
+            - `runtime/forgeclient_session.env.example`
+            - `scripts/run_forgeclient_replay.sh`
+            - `scripts/attach_forgeclient_replay_pid.sh`
+            """
+        )
+        replay_steps = textwrap.dedent(
+            """\
+
+            Launcher-faithful replay lane:
+            1. `./scripts/run_forgeclient_replay.sh --dry-run`
+            2. confirm the rendered command still targets `forgeclient`
+            3. `./scripts/run_forgeclient_replay.sh --preload-mode spoof`
+            4. if `gdb --args` is unstable on this host, use exact-PID attach instead:
+               - terminal A: `./scripts/run_forgeclient_replay.sh --preload-mode spoof --pid-file runtime/forgeclient_replay.pid --pause-before-exec-ms 5000`
+               - terminal B: `./scripts/attach_forgeclient_replay_pid.sh runtime/forgeclient_replay.pid`
+            """
+        )
+    text = textwrap.dedent(
+        f"""\
+        # YSM 2.6.2 VM Bundle
+
+        Purpose:
+        - compatibility and porting research for legacy Yes Steve Model decoding
+        - helping macOS players and forward-porting the mod
+        - not malware development
+
+        Suggested stack:
+        - root-managed `qemu/libvirt`
+        - Linux guest
+        - `gdb`, `java`, `javac`, `jar`, `javap`
+
+        QEMU/libvirt notes:
+        - prefer snapshots/checkpoints before each debugging pass
+        - disable guest-agent or tools-driven time synchronization where possible
+        - avoid relying on VMware-specific keys like `tools.syncTime`; use the QEMU/libvirt equivalents on the host and in the guest config
+        - use QEMU gdbstub or in-guest `gdb` as needed; do not assume a direct equivalent for every VMware anti-debug option
+
+        Included samples:
+        {samples_rendered}
+
+        Bundle contents:
+        - `official/{jar_name}`
+        - `native/`
+        - `runtime/classpath.txt`
+        - `runtime/bootstrap_legacy_classpath.txt`
+        - `runtime/runtime_audit.json`
+        - `src/NativeLibraryLoadProbe.java`
+        - `src/YsmNativeStartupGateProbe.java`
+        - `src/YsmBootstrapProbeLaunchHandler.java`
+        - `src/YsmBootstrapProbeMain.java`
+        - `bootstrap_probe_resources/META-INF/services/cpw.mods.modlauncher.api.ILaunchHandlerService`
+        - `native_tools/ysm262_dlopen_probe.c`
+        - `native_tools/ysm262_jni_probe.c`
+        - `native_tools/ysm262_intercept.c`
+        - `stubs/src/`
+        - `scripts/run_startup_gate_probe.sh`
+        - `scripts/run_jni_probe.sh`
+        - `scripts/run_bootstrap_probe.sh`
+        - `scripts/native_antidebug_probe.py`
+        - `scripts/ghidra_find_antidebug_refs.py`
+        - `scripts/ghidra_recover_guard_mechanics.py`
+        - `scripts/ghidra_dump_targets.py`
+        - `scripts/attach_forgeclient_replay_pid.sh`
+        - `gdb/ysm262_jni_bootstrap.gdb`
+        - `gdb/ysm262_err56_trace.gdb`
+        - `gdb/ysm262_startup_gate.gdb`
+        - `gdb/ysm262_antidebug_min.gdb`
+        - `gdb/ysm262_antidebug_route_trace.gdb`
+        - `native_bundle_manifest.json`
+        {replay_contents.rstrip()}
+
+        Suggested first runtime checks inside the guest:
+        1. `cat runtime/runtime_audit.json`
+        2. `./scripts/run_bootstrap_probe.sh --phase scan`
+        3. `./scripts/run_bootstrap_probe.sh --phase mc_bootstrap`
+        4. `YSM262_TRACE_JNI_ENV=0 ./scripts/run_bootstrap_probe.sh --phase gather --invoke-native startup-gate --preload-mode spoof`
+        5. `./scripts/run_jni_probe.sh --with-stubs --preload-mode spoof`
+
+        Current primary live-debug lane:
+        1. `cd <bundle-dir>`
+        2. `YSM262_TRACE_JNI_ENV=0 ./scripts/run_bootstrap_probe.sh --phase gather --invoke-native startup-gate --preload-mode spoof`
+        3. confirm the non-GDB control still reaches `err: 56`
+        4. `YSM262_TRACE_JNI_ENV=0 ./scripts/run_bootstrap_probe.sh --gdb --phase gather --invoke-native startup-gate --preload-mode spoof --pause-before-native-call-ms 5000`
+        5. inside gdb, the default preset auto-loads: `gdb/ysm262_err56_trace.gdb`
+        6. let `JNI_OnLoad` install the absolute native breakpoints, then inspect the first `FUN_00516260` stop
+        7. only fall back to the direct Java probe if the bootstrap path stops reproducing `err: 56`: `{java_run}`
+
+        Separate anti-debug lane:
+        1. `python3 scripts/native_antidebug_probe.py`
+        2. confirm the bundle-local interposer is fresh:
+           - `rg 'YSM262_TRACE_ANTIDEBUG|system-inline|kill-inline' native_tools/ysm262_intercept.c`
+        3. run the Ghidra helpers inside the persistent project and read the repo-local reports:
+           - `scripts/ghidra_find_antidebug_refs.py ../ghidra/reports/ghidra_antidebug_refs_report.txt`
+           - `scripts/ghidra_recover_guard_mechanics.py ../ghidra/reports/ghidra_guard_mechanics_report.txt`
+        4. use launcher-faithful replay without GDB first:
+           - `YSM262_TRACE_ANTIDEBUG=1 ./scripts/run_forgeclient_replay.sh --preload-mode spoof`
+        5. for debugger-triggered reproduction, prefer the minimal anti-debug preset:
+           - `YSM262_TRACE_ANTIDEBUG=1 ./scripts/run_forgeclient_replay.sh --gdb --gdb-script gdb/ysm262_antidebug_min.gdb --preload-mode spoof`
+        6. if `gdb --args` is unstable, use exact-PID attach instead of `--gdb`:
+           - terminal A: `YSM262_TRACE_ANTIDEBUG=1 ./scripts/run_forgeclient_replay.sh --preload-mode spoof --pid-file runtime/forgeclient_replay.pid --pause-before-exec-ms 5000`
+           - terminal B: `./scripts/attach_forgeclient_replay_pid.sh runtime/forgeclient_replay.pid`
+        7. for route-mapping after the wrapper soup is understood, use the focused anti-debug route preset:
+           - `YSM262_TRACE_ANTIDEBUG=1 ./scripts/run_forgeclient_replay.sh --gdb --gdb-script gdb/ysm262_antidebug_route_trace.gdb --preload-mode spoof`
+           - or on the attach lane: `./scripts/attach_forgeclient_replay_pid.sh runtime/forgeclient_replay.pid gdb/ysm262_antidebug_route_trace.gdb`
+           - it traces `FUN_010d4554`, `FUN_0123d0c1`, the `014ca8e5/014ca942` response branch, and the poison/system/kill terminals
+           - if you want the GDB-side route output saved, launch with `YSM262_GDB_ROUTE_LOG=runtime/route_trace.gdb.log`
+        8. if needed, simulate the first debugger hypothesis without GDB:
+           - `YSM262_TRACE_ANTIDEBUG=1 YSM262_SIMULATE_PTRACE_TRACEME_EPERM=1 ./scripts/run_forgeclient_replay.sh --preload-mode spoof`
+        9. once the caller rel is known, suppress only that caller:
+           - `YSM262_SPOOF_ANTIDEBUG_ACTION=suppress`
+           - `YSM262_SPOOF_ANTIDEBUG_CALLER_RELS=<hex,...>`
+
+        Current verdict:
+        - default repo-local runtime-debug root is `ROOT/debug_runtime`; override with `{DEFAULT_DEBUG_RUNTIME_ENV}`
+        - the canonical replay bundle path is `ROOT/debug_runtime/vm_bundle_guest_gdb_use_case`
+        - the canonical launcher command capture path is `ROOT/debug_runtime/launcher/forgeclient_command_use_case.txt`
+        - the persistent Ghidra project and reports live under `ROOT/debug_runtime/ghidra/`
+        - use this guest-side bootstrap + spoof + gdb lane as the primary dynamic debugger
+        - use headed-host `0x4d4140` tracing only as a control/corroboration lane
+        - do not spend time on new headed-host direct rel retargets unless guest-side resolver work is blocked
+        {replay_steps.rstrip()}
+        """
+    )
+    (out_dir / "README.md").write_text(text, encoding="utf-8")
+
+
+def _write_load_probe(out_dir: Path) -> None:
+    src_dir = out_dir / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    source = textwrap.dedent(
+        """\
+        public final class NativeLibraryLoadProbe {
+            public static void main(String[] args) {
+                if (args.length != 1) {
+                    System.err.println("usage: java NativeLibraryLoadProbe /absolute/path/to/libysm-core.so");
+                    System.exit(2);
+                }
+                try {
+                    System.load(args[0]);
+                    System.out.println("load_ok");
+                } catch (Throwable t) {
+                    t.printStackTrace(System.err);
+                    System.exit(1);
+                }
+            }
+        }
+        """
+    )
+    (src_dir / "NativeLibraryLoadProbe.java").write_text(source, encoding="utf-8")
+
+
+def _default_linux_native_name(native_entries: Sequence[str]) -> str | None:
+    for entry in native_entries:
+        name = Path(entry).name
+        if name.endswith(".so"):
+            return name
+    return Path(native_entries[0]).name if native_entries else None
+
+
+def _write_startup_gate_launcher(out_dir: Path, *, jar_name: str, linux_native_name: str | None) -> None:
+    if linux_native_name is None:
+        return
+    scripts_dir = out_dir / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    launcher = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        ROOT=$(cd "$(dirname "${{BASH_SOURCE[0]}}")/.." && pwd)
+        BUILD_DIR="$ROOT/build"
+        SRC="$ROOT/src/YsmNativeStartupGateProbe.java"
+        JAR="$ROOT/official/{jar_name}"
+        LIB="$ROOT/native/{linux_native_name}"
+
+        mkdir -p "$BUILD_DIR"
+        javac -d "$BUILD_DIR" "$SRC"
+        exec java -cp "$BUILD_DIR" YsmNativeStartupGateProbe --jar "$JAR" --lib "$LIB" "$@"
+        """
+    )
+    target = scripts_dir / "run_startup_gate_probe.sh"
+    target.write_text(launcher, encoding="utf-8")
+    os.chmod(target, 0o755)
+
+
+def _write_jni_probe_launcher(out_dir: Path, *, jar_name: str, linux_native_name: str | None) -> None:
+    if linux_native_name is None:
+        return
+    scripts_dir = out_dir / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    launcher = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        ROOT=$(cd "$(dirname "${{BASH_SOURCE[0]}}")/.." && pwd)
+        BUILD_DIR="$ROOT/build/native"
+        LIB="$ROOT/native/{linux_native_name}"
+        OFFICIAL_JAR="$ROOT/official/{jar_name}"
+        STUB_CLASSES="$ROOT/build/stubs"
+        STUB_JAR="$ROOT/build/ysm262_vm_stubs.jar"
+        REAL_JAVA_EXE=$(readlink -f "$(command -v java)")
+        JAVA_HOME_DIR=$(dirname "$(dirname "$REAL_JAVA_EXE")")
+        export LD_LIBRARY_PATH="$JAVA_HOME_DIR/lib/server${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}"
+
+        WITH_STUBS=0
+        PRELOAD_MODE=off
+        EXTRA_CP=()
+
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --with-stubs)
+              WITH_STUBS=1
+              shift
+              ;;
+            --preload-mode)
+              PRELOAD_MODE="${{2:-}}"
+              shift 2
+              ;;
+            --classpath-append)
+              EXTRA_CP+=("${{2:-}}")
+              shift 2
+              ;;
+            --help|-h)
+              cat <<'EOF'
+        usage: run_jni_probe.sh [--with-stubs] [--preload-mode off|log|spoof] [--classpath-append /path/to/jar]
+
+        notes:
+          - spoof mode defaults YSM262_SPOOF_PROC_SELF_EXE to the resolved real java launcher
+          - spoof mode also defaults hostname to localhost and affinity to cpu0-only to keep the native path stable
+          - spoof mode also defaults dladdr JVM-origin spoofing to $JAVA_HOME_DIR/lib/server/libjvm.so
+          - override YSM262_SPOOF_PROC_SELF_EXE explicitly if the VM guest should spoof a different launcher path
+        EOF
+              exit 0
+              ;;
+            *)
+              echo "unknown argument: $1" >&2
+              exit 2
+              ;;
+          esac
+        done
+
+        mkdir -p "$BUILD_DIR"
+        cc -O0 -g "$ROOT/native_tools/ysm262_jni_probe.c" \
+          -I"$JAVA_HOME_DIR/include" -I"$JAVA_HOME_DIR/include/linux" \
+          -L"$JAVA_HOME_DIR/lib/server" -ljvm -ldl \
+          -o "$BUILD_DIR/ysm262_jni_probe"
+        cc -shared -fPIC -O0 -g "$ROOT/native_tools/ysm262_intercept.c" \
+          -I"$JAVA_HOME_DIR/include" -I"$JAVA_HOME_DIR/include/linux" -pthread -ldl \
+          -o "$BUILD_DIR/libysm262_intercept.so"
+
+        CP="$OFFICIAL_JAR"
+        while IFS= read -r rel; do
+          [[ -z "$rel" ]] && continue
+          CP="$CP:$ROOT/$rel"
+        done < "$ROOT/runtime/classpath.txt"
+
+        if [[ "$WITH_STUBS" -eq 1 ]]; then
+          rm -rf "$STUB_CLASSES"
+          mkdir -p "$STUB_CLASSES"
+          find "$ROOT/stubs/src" -name '*.java' -print0 | xargs -0 javac -d "$STUB_CLASSES"
+          jar --create --file "$STUB_JAR" -C "$STUB_CLASSES" .
+          CP="$CP:$STUB_JAR"
+        fi
+
+        for extra in "${{EXTRA_CP[@]}}"; do
+          CP="$CP:$extra"
+        done
+
+        if [[ "$PRELOAD_MODE" != "off" ]]; then
+          export LD_PRELOAD="$BUILD_DIR/libysm262_intercept.so${{LD_PRELOAD:+:$LD_PRELOAD}}"
+          export YSM262_INTERCEPT_LOG="${{YSM262_INTERCEPT_LOG:-$BUILD_DIR/ysm262_intercept.log}}"
+          if [[ "$PRELOAD_MODE" == "spoof" ]]; then
+            export YSM262_SPOOF_PROC_SELF_EXE="${{YSM262_SPOOF_PROC_SELF_EXE:-$REAL_JAVA_EXE}}"
+            export YSM262_SPOOF_DLADDR_LIBJVM="${{YSM262_SPOOF_DLADDR_LIBJVM:-$JAVA_HOME_DIR/lib/server/libjvm.so}}"
+            export YSM262_SPOOF_DLADDR_JVM_ORIGINS="${{YSM262_SPOOF_DLADDR_JVM_ORIGINS:-1}}"
+            export YSM262_SPOOF_PRCTL_VM="1"
+            export YSM262_SPOOF_HOSTNAME="${{YSM262_SPOOF_HOSTNAME:-localhost}}"
+            export YSM262_SPOOF_AFFINITY_ONECPU="${{YSM262_SPOOF_AFFINITY_ONECPU:-1}}"
+            export YSM262_TRACE_JNI_ENV="${{YSM262_TRACE_JNI_ENV:-1}}"
+          fi
+        fi
+
+        exec "$BUILD_DIR/ysm262_jni_probe" "$LIB" "$CP"
+        """
+    )
+    target = scripts_dir / "run_jni_probe.sh"
+    target.write_text(launcher, encoding="utf-8")
+    os.chmod(target, 0o755)
+
+
+def _write_bootstrap_probe_launcher(
+    out_dir: Path,
+    *,
+    jar_name: str,
+    linux_native_name: str | None,
+    version_id: str,
+    bootstrap_info: ForgeBootstrapInfo,
+) -> None:
+    if linux_native_name is None:
+        return
+    scripts_dir = out_dir / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    launcher_main_class = bootstrap_info.main_class or DEFAULT_BOOTSTRAP_MAIN_CLASS
+    forge_version = bootstrap_info.forge_version or (version_id.partition("-forge-")[2] or version_id)
+    mcp_version = bootstrap_info.mcp_version or DEFAULT_FORGE_MCP_VERSION
+    launcher = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        ROOT=$(cd "$(dirname "${{BASH_SOURCE[0]}}")/.." && pwd)
+        BUILD_DIR="$ROOT/build/bootstrap_probe"
+        CLASS_DIR="$BUILD_DIR/classes"
+        PROBE_JAR="$BUILD_DIR/ysm262_bootstrap_probe.jar"
+        OFFICIAL_JAR="$ROOT/official/{jar_name}"
+        NATIVE_LIB="$ROOT/native/{linux_native_name}"
+        REAL_JAVA_EXE=$(readlink -f "$(command -v java)")
+        JAVA_HOME_DIR=$(dirname "$(dirname "$REAL_JAVA_EXE")")
+        PROBE_CP_FILE="$ROOT/runtime/bootstrap_legacy_classpath.txt"
+        COMPILE_CP_FILE="$ROOT/runtime/classpath.txt"
+        RESOURCE_DIR="$ROOT/bootstrap_probe_resources"
+        LAUNCHER_MAIN_CLASS="{launcher_main_class}"
+        DEFAULT_PHASE="scan"
+        INVOKE_NATIVE="none"
+        PRELOAD_MODE=off
+        PAUSE_BEFORE_NATIVE_LOAD_MS=""
+        PAUSE_BEFORE_NATIVE_CALL_MS=""
+        USE_GDB=0
+        GDB_SCRIPT="$ROOT/gdb/ysm262_err56_trace.gdb"
+        EXTRA_ARGS=()
+
+        render_classpath() {{
+          local file="$1"
+          local cp=""
+          while IFS= read -r rel; do
+            [[ -z "$rel" ]] && continue
+            if [[ -z "$cp" ]]; then
+              cp="$ROOT/$rel"
+            else
+              cp="$cp:$ROOT/$rel"
+            fi
+          done < "$file"
+          printf '%s' "$cp"
+        }}
+
+        collect_module_path() {{
+          local file="$1"
+          local mp=""
+          while IFS= read -r rel; do
+            [[ -z "$rel" ]] && continue
+            local name="${{rel##*/}}"
+            case "$name" in
+              bootstraplauncher-*.jar|securejarhandler-*.jar|asm-commons-*.jar|asm-util-*.jar|asm-analysis-*.jar|asm-tree-*.jar|asm-*.jar|JarJarFileSystems-*.jar)
+                if [[ -z "$mp" ]]; then
+                  mp="$ROOT/$rel"
+                else
+                  mp="$mp:$ROOT/$rel"
+                fi
+                ;;
+            esac
+          done < "$file"
+          printf '%s' "$mp"
+        }}
+
+        collect_merge_modules() {{
+          local file="$1"
+          local merged=""
+          while IFS= read -r rel; do
+            [[ -z "$rel" ]] && continue
+            local name="${{rel##*/}}"
+            case "$name" in
+              jna-*.jar|jna-platform-*.jar)
+                if [[ -z "$merged" ]]; then
+                  merged="$name"
+                else
+                  merged="$merged,$name"
+                fi
+                ;;
+            esac
+          done < "$file"
+          printf '%s' "$merged"
+        }}
+
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --phase)
+              DEFAULT_PHASE="${{2:-}}"
+              shift 2
+              ;;
+            --invoke-native)
+              INVOKE_NATIVE="${{2:-}}"
+              shift 2
+              ;;
+            --preload-mode)
+              PRELOAD_MODE="${{2:-}}"
+              shift 2
+              ;;
+            --pause-before-native-load-ms)
+              PAUSE_BEFORE_NATIVE_LOAD_MS="${{2:-}}"
+              shift 2
+              ;;
+            --pause-before-native-call-ms)
+              PAUSE_BEFORE_NATIVE_CALL_MS="${{2:-}}"
+              shift 2
+              ;;
+            --gdb)
+              USE_GDB=1
+              shift
+              ;;
+            --gdb-script)
+              GDB_SCRIPT="${{2:-}}"
+              shift 2
+              ;;
+            --help|-h)
+              cat <<'EOF'
+        usage: run_bootstrap_probe.sh [--phase scan|mc_bootstrap|gather] [--invoke-native load-only|startup-gate] [--preload-mode off|log|spoof] [--pause-before-native-load-ms N] [--pause-before-native-call-ms N] [--gdb] [--gdb-script /path/to/script.gdb] [extra probe args]
+
+        notes:
+          - this launches the real Forge BootstrapLauncher path with a custom ForgeClientLaunchHandler target
+          - later phases include earlier ones
+          - native checkpoints reuse the official mod jar and staged native library to compare progress toward the format 15/9 decode path
+          - preload spoof mode reuses the same interposer defaults as run_jni_probe.sh
+          - --gdb defaults to sourcing gdb/ysm262_err56_trace.gdb before running the canonical bootstrap gather path
+          - for the authentic host-side err:56 path, prefer YSM262_TRACE_JNI_ENV=0
+        EOF
+              exit 0
+              ;;
+            *)
+              EXTRA_ARGS+=("$1")
+              shift
+              ;;
+          esac
+        done
+
+        COMPILE_CP=$(render_classpath "$COMPILE_CP_FILE")
+        MODULE_PATH=$(collect_module_path "$PROBE_CP_FILE")
+        MERGE_MODULES=$(collect_merge_modules "$PROBE_CP_FILE")
+        RUNTIME_CP=$(render_classpath "$PROBE_CP_FILE")
+        RUNTIME_CP="$RUNTIME_CP:$PROBE_JAR"
+
+        rm -rf "$CLASS_DIR"
+        mkdir -p "$CLASS_DIR"
+        javac -cp "$COMPILE_CP" -d "$CLASS_DIR" \
+          "$ROOT/src/YsmBootstrapProbeLaunchHandler.java" \
+          "$ROOT/src/YsmBootstrapProbeMain.java"
+        rm -f "$PROBE_JAR"
+        jar --create --file "$PROBE_JAR" -C "$CLASS_DIR" . -C "$RESOURCE_DIR" .
+
+        if [[ "$PRELOAD_MODE" != "off" ]]; then
+          mkdir -p "$BUILD_DIR"
+          cc -shared -fPIC -O0 -g "$ROOT/native_tools/ysm262_intercept.c" \
+            -I"$JAVA_HOME_DIR/include" -I"$JAVA_HOME_DIR/include/linux" -pthread -ldl \
+            -o "$BUILD_DIR/libysm262_intercept.so"
+          export LD_PRELOAD="$BUILD_DIR/libysm262_intercept.so${{LD_PRELOAD:+:$LD_PRELOAD}}"
+          export YSM262_INTERCEPT_LOG="${{YSM262_INTERCEPT_LOG:-$BUILD_DIR/ysm262_intercept.log}}"
+          if [[ "$PRELOAD_MODE" == "spoof" ]]; then
+            export YSM262_SPOOF_PROC_SELF_EXE="${{YSM262_SPOOF_PROC_SELF_EXE:-$REAL_JAVA_EXE}}"
+            export YSM262_SPOOF_DLADDR_LIBJVM="${{YSM262_SPOOF_DLADDR_LIBJVM:-$JAVA_HOME_DIR/lib/server/libjvm.so}}"
+            export YSM262_SPOOF_DLADDR_JVM_ORIGINS="${{YSM262_SPOOF_DLADDR_JVM_ORIGINS:-1}}"
+            export YSM262_SPOOF_PRCTL_VM="1"
+            export YSM262_SPOOF_HOSTNAME="${{YSM262_SPOOF_HOSTNAME:-localhost}}"
+            export YSM262_SPOOF_AFFINITY_ONECPU="${{YSM262_SPOOF_AFFINITY_ONECPU:-1}}"
+            export YSM262_TRACE_JNI_ENV="${{YSM262_TRACE_JNI_ENV:-1}}"
+          fi
+        fi
+
+        JAVA_ARGS=(
+          "-Djava.net.preferIPv6Addresses=system"
+          "-DignoreList={bootstrap_info.ignore_list}"
+          "-DlibraryDirectory=$ROOT/runtime/libraries"
+          "-p" "$MODULE_PATH"
+          "--add-modules" "ALL-MODULE-PATH"
+          "--add-opens" "java.base/java.util.jar=cpw.mods.securejarhandler"
+          "--add-opens" "java.base/java.lang.invoke=cpw.mods.securejarhandler"
+          "--add-exports" "java.base/sun.security.util=cpw.mods.securejarhandler"
+          "--add-exports" "jdk.naming.dns/com.sun.jndi.dns=java.naming"
+          "-cp" "$RUNTIME_CP"
+          "$LAUNCHER_MAIN_CLASS"
+          "--launchTarget" "ysmprobeclient"
+          "--fml.forgeVersion" "{forge_version}"
+          "--fml.mcVersion" "{bootstrap_info.minecraft_version}"
+          "--fml.forgeGroup" "net.minecraftforge"
+          "--fml.mcpVersion" "{mcp_version}"
+          "--phase" "$DEFAULT_PHASE"
+          "--official-jar" "$OFFICIAL_JAR"
+          "--native-lib" "$NATIVE_LIB"
+        )
+
+        if [[ -n "$MERGE_MODULES" ]]; then
+          JAVA_ARGS=("-DmergeModules=$MERGE_MODULES" "${{JAVA_ARGS[@]}}")
+        fi
+        if [[ "$INVOKE_NATIVE" != "none" ]]; then
+          JAVA_ARGS+=("--invoke-native" "$INVOKE_NATIVE")
+        fi
+        if [[ -n "$PAUSE_BEFORE_NATIVE_LOAD_MS" ]]; then
+          JAVA_ARGS+=("--pause-before-native-load-ms" "$PAUSE_BEFORE_NATIVE_LOAD_MS")
+        fi
+        if [[ -n "$PAUSE_BEFORE_NATIVE_CALL_MS" ]]; then
+          JAVA_ARGS+=("--pause-before-native-call-ms" "$PAUSE_BEFORE_NATIVE_CALL_MS")
+        fi
+        JAVA_ARGS+=("${{EXTRA_ARGS[@]}}")
+
+        if [[ "$USE_GDB" -eq 1 ]]; then
+          GDB_ARGS=("-q")
+          if [[ -n "$GDB_SCRIPT" ]]; then
+            GDB_ARGS+=("-ex" "source $GDB_SCRIPT")
+          fi
+          exec gdb "${{GDB_ARGS[@]}}" --args java "${{JAVA_ARGS[@]}}"
+        fi
+
+        exec java "${{JAVA_ARGS[@]}}"
+        """
+    )
+    target = scripts_dir / "run_bootstrap_probe.sh"
+    target.write_text(launcher, encoding="utf-8")
+    os.chmod(target, 0o755)
+
+
+def _copy_vm_debug_assets(out_dir: Path) -> list[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    vm_debug_dir = repo_root / "vm_debug"
+    copied: list[str] = []
+    if not vm_debug_dir.is_dir():
+        return copied
+
+    src_dir = out_dir / "src"
+    gdb_dir = out_dir / "gdb"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    gdb_dir.mkdir(parents=True, exist_ok=True)
+
+    for name in (
+        "YsmNativeStartupGateProbe.java",
+        "YsmBootstrapProbeLaunchHandler.java",
+        "YsmBootstrapProbeMain.java",
+        "ysm262_dlopen_probe.c",
+        "ysm262_jni_probe.c",
+        "ysm262_intercept.c",
+        "ysm262_ptrace_exec.c",
+    ):
+        src = vm_debug_dir / name
+        if src.is_file():
+            target_dir = src_dir if name.endswith(".java") else out_dir / "native_tools"
+            target_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, target_dir / src.name)
+            copied.append(f"{target_dir.relative_to(out_dir)}/{src.name}")
+
+    bootstrap_resource_dir = vm_debug_dir / "bootstrap_probe_resources"
+    if bootstrap_resource_dir.is_dir():
+        for src in sorted(path for path in bootstrap_resource_dir.rglob("*") if path.is_file()):
+            rel = src.relative_to(vm_debug_dir)
+            target = out_dir / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, target)
+            copied.append(str(rel))
+
+    stubs_src = vm_debug_dir / "stubs" / "src"
+    if stubs_src.is_dir():
+        for src in sorted(path for path in stubs_src.rglob("*.java") if path.is_file()):
+            rel = src.relative_to(vm_debug_dir)
+            target = out_dir / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, target)
+            copied.append(str(rel))
+
+    for name in (
+        "ysm262_jni_bootstrap.gdb",
+        "ysm262_err56_trace.gdb",
+        "ysm262_startup_gate.gdb",
+        "ysm262_antidebug_min.gdb",
+        "ysm262_antidebug_route_trace.gdb",
+    ):
+        src = vm_debug_dir / name
+        if src.is_file():
+            shutil.copy2(src, gdb_dir / src.name)
+            copied.append(f"gdb/{src.name}")
+
+    return copied
+
+
+def stage_vm_bundle(
+    out_dir: Path | None,
+    *,
+    official_jar: Path | None = None,
+    sample_paths: Sequence[Path] = (),
+    launcher_command_file: Path | None = None,
+    minecraft_root: Path = DEFAULT_MINECRAFT_ROOT,
+    version_id: str = DEFAULT_FORGE_VERSION_ID,
+) -> Path:
+    out_dir = (out_dir or _default_vm_bundle_out_dir()).resolve()
+    baseline = probe_ysm262_official(official_jar)
+    if baseline is None:
+        raise SystemExit("could not find ysm-2.6.2-forge+mc1.20.1-release.jar")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    official_dir = out_dir / "official"
+    native_dir = out_dir / "native"
+    sample_dir = out_dir / "samples"
+    official_dir.mkdir(exist_ok=True)
+    native_dir.mkdir(exist_ok=True)
+    sample_dir.mkdir(exist_ok=True)
+    scripts_dir = out_dir / "scripts"
+    scripts_dir.mkdir(exist_ok=True)
+
+    jar_copy = official_dir / baseline.jar_path.name
+    shutil.copy2(baseline.jar_path, jar_copy)
+
+    with zipfile.ZipFile(baseline.jar_path) as zf:
+        for entry in baseline.native_entries:
+            target = native_dir / Path(entry).name
+            target.write_bytes(zf.read(entry))
+
+    staged_samples: list[Path] = []
+    for sample in sample_paths:
+        sample = sample.resolve()
+        if not sample.is_file():
+            raise FileNotFoundError(sample)
+        shutil.copy2(sample, sample_dir / sample.name)
+        staged_samples.append(Path("samples") / sample.name)
+
+    repo_root = _repo_root()
+    for helper_name in (
+        "native_antidebug_probe.py",
+        "ghidra_find_antidebug_refs.py",
+        "ghidra_recover_guard_mechanics.py",
+        "ghidra_dump_targets.py",
+    ):
+        helper = repo_root / helper_name
+        if helper.is_file():
+            shutil.copy2(helper, scripts_dir / helper.name)
+
+    _write_load_probe(out_dir)
+    copied_debug_assets = _copy_vm_debug_assets(out_dir)
+    linux_native_name = _default_linux_native_name(baseline.native_entries)
+    _write_startup_gate_launcher(out_dir, jar_name=baseline.jar_path.name, linux_native_name=linux_native_name)
+    _write_jni_probe_launcher(out_dir, jar_name=baseline.jar_path.name, linux_native_name=linux_native_name)
+    runtime_audit = _collect_runtime_audit(minecraft_root, version_id=version_id)
+    bootstrap_info = _resolve_forge_bootstrap_info(minecraft_root, version_id=version_id)
+    _write_bootstrap_probe_launcher(
+        out_dir,
+        jar_name=baseline.jar_path.name,
+        linux_native_name=linux_native_name,
+        version_id=version_id,
+        bootstrap_info=bootstrap_info,
+    )
+    runtime_report = _write_runtime_bundle(out_dir, runtime_audit)
+    launcher_replay: dict[str, Any] | None = None
+    if launcher_command_file is not None:
+        launcher_command_file = launcher_command_file.resolve()
+        if not launcher_command_file.is_file():
+            raise FileNotFoundError(launcher_command_file)
+        replay_command = _parse_launcher_command_file(
+            launcher_command_file,
+            expected_main_classes=tuple(
+                candidate
+                for candidate in (runtime_report["main_class"], DEFAULT_BOOTSTRAP_MAIN_CLASS)
+                if candidate
+            ),
+        )
+        launcher_replay = _write_launcher_replay_artifacts(
+            out_dir,
+            command=replay_command,
+            linux_native_name=linux_native_name,
+        )
+    _write_vm_bundle_readme(
+        out_dir,
+        jar_name=baseline.jar_path.name,
+        linux_native_name=linux_native_name,
+        sample_paths=staged_samples,
+        launcher_replay=launcher_replay,
+    )
+
+    manifest = {
+        "purpose": (
+            "Compatibility and porting research for Yes Steve Model legacy 9/15 decoding. "
+            "This bundle is for benign reverse-engineering and verification, not malware development."
+        ),
+        "official_jar": str(jar_copy),
+        "official_jar_sha256": baseline.jar_sha256,
+        "native_entries": list(baseline.native_entries),
+        "native_sha256": list(baseline.native_sha256),
+        "loader_classes": list(baseline.loader_classes),
+        "export_classes": list(baseline.export_classes),
+        "samples": [str(path) for path in staged_samples],
+        "helper_scripts": sorted(path.name for path in scripts_dir.iterdir() if path.is_file()),
+        "debug_assets": copied_debug_assets,
+        "default_linux_native": linux_native_name,
+        "minecraft_root": str(minecraft_root),
+        "runtime_version_id": version_id,
+        "runtime_main_class": runtime_report["main_class"],
+        "runtime_minecraft_version": runtime_report["minecraft_version"],
+        "runtime_forge_version": runtime_report["forge_version"],
+        "runtime_mcp_version": runtime_report["mcp_version"],
+        "runtime_entry_count": len(runtime_report["classpath_entries"]),
+        "runtime_missing_count": len(runtime_report["missing"]),
+        "launcher_replay": launcher_replay,
+    }
+    (out_dir / "native_bundle_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return out_dir
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Tools for staging YSM 2.6.2 official export snapshots and debug bundles.")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    snap = sub.add_parser("snapshot", help="normalize an official export folder into a canonical snapshot")
+    snap.add_argument("export_root", type=Path, help="official export folder to snapshot")
+    snap.add_argument("--out-dir", type=Path, help="output folder for the normalized snapshot")
+    snap.add_argument("--ysm-path", type=Path, help="optional source .ysm path for naming/manifest context")
+    snap.add_argument("--official-jar", type=Path, help="override the 2.6.2 official jar path")
+
+    bundle = sub.add_parser("stage-vm", help="stage the primary guest-side qemu/libvirt VM debug bundle for 2.6.2")
+    bundle.add_argument(
+        "--out-dir",
+        type=Path,
+        help=(
+            "bundle output directory; defaults to "
+            f"{_default_vm_bundle_out_dir()} or ${DEFAULT_DEBUG_RUNTIME_ENV}/vm_bundle_guest_gdb_use_case"
+        ),
+    )
+    bundle.add_argument("--official-jar", type=Path, help="override the 2.6.2 official jar path")
+    bundle.add_argument("--sample", type=Path, action="append", default=[], help="optional sample .ysm to copy into the bundle")
+    bundle.add_argument(
+        "--launcher-command-file",
+        type=Path,
+        help="optional captured raw launcher command file to convert into a launcher-faithful forgeclient replay script",
+    )
+    bundle.add_argument("--minecraft-root", type=Path, default=DEFAULT_MINECRAFT_ROOT, help="Minecraft runtime root to harvest dependencies from")
+    bundle.add_argument("--version-id", default=DEFAULT_FORGE_VERSION_ID, help="Forge version id to harvest runtime dependencies from")
+
+    headed = sub.add_parser("stage-headed-host", help="stage a headed host control/debug bundle for the real Forge client")
+    headed.add_argument(
+        "--out-dir",
+        type=Path,
+        help=(
+            "bundle output directory; defaults to "
+            f"{_default_headed_host_out_dir()} or ${DEFAULT_DEBUG_RUNTIME_ENV}/headed_host_bundle"
+        ),
+    )
+    headed.add_argument("--minecraft-root", type=Path, default=DEFAULT_MINECRAFT_ROOT, help="Minecraft runtime root to mirror")
+    headed.add_argument("--version-id", default=DEFAULT_FORGE_VERSION_ID, help="Forge version id for the dedicated launcher profile")
+    headed.add_argument(
+        "--launcher-profiles",
+        type=Path,
+        default=DEFAULT_MINECRAFT_ROOT / "launcher_profiles.json",
+        help="launcher_profiles.json to inspect when preparing the profile payload",
+    )
+    headed.add_argument("--profile-id", default=DEFAULT_HEADED_DEBUG_PROFILE_ID, help="launcher profile id to create/update")
+    headed.add_argument("--profile-name", default=DEFAULT_HEADED_DEBUG_PROFILE_NAME, help="launcher profile display name")
+    headed.add_argument("--model-trace", action="store_true", help="enable the focused model-state trace lane in the headed wrapper")
+    headed.add_argument("--model-trace-sample", help="sample path/name substring that arms focused model tracing")
+    headed.add_argument("--model-trace-families", help="comma-separated bone/family tokens to highlight in model-trace scans")
+    headed.add_argument("--model-trace-export-filter", default="main.json", help="export json basename to treat as the main model truth target")
+    headed.add_argument("--model-trace-rel", default="0x4e2c80", help="inline-hook rel target for the focused model trace lane")
+    headed.add_argument("--model-trace-patch-len", type=int, default=16, help="patch length for the focused model trace hook")
+    headed.add_argument("--model-trace-limit", type=int, default=32, help="budget of focused model-trace invocations")
+    headed.add_argument("--model-trace-scan-bytes", default="0x240", help="bytes to scan per candidate object during model trace")
+    headed.add_argument("--model-trace-string-limit", type=int, default=64, help="max string observations per model-trace object")
+    headed.add_argument("--model-trace-vector-limit", type=int, default=48, help="max float3 observations per model-trace object")
+
+    capture = sub.add_parser(
+        "capture-legacy-export",
+        help="stage one legacy .ysm into the headed client path for corroboration trace and optional export/snapshot capture",
+    )
+    capture.add_argument("ysm_path", type=Path, help="legacy .ysm sample to stage")
+    capture.add_argument("--out-dir", type=Path, help="capture bundle output directory")
+    capture.add_argument("--minecraft-root", type=Path, default=DEFAULT_MINECRAFT_ROOT, help="Minecraft runtime root to mirror")
+    capture.add_argument("--version-id", default=DEFAULT_FORGE_VERSION_ID, help="Forge version id for the dedicated launcher profile")
+    capture.add_argument(
+        "--launcher-profiles",
+        type=Path,
+        default=DEFAULT_MINECRAFT_ROOT / "launcher_profiles.json",
+        help="launcher_profiles.json to inspect when preparing the profile payload",
+    )
+    capture.add_argument("--profile-id", help="launcher profile id to create/update")
+    capture.add_argument("--profile-name", help="launcher profile display name")
+    capture.add_argument("--model-id", help="override the imported model id used by `/ysm export`")
+    capture.add_argument("--extra", help="optional extra argument string to append to `/ysm export <model_id>`")
+    capture.add_argument("--export-root", type=Path, help="override the raw official export root to harvest")
+    capture.add_argument("--snapshot-dir", type=Path, help="output folder for the canonical official snapshot")
+    capture.add_argument("--keep-existing", action="store_true", help="do not clear staged custom/export state before preparing the capture")
+    capture.add_argument("--trace-only", action="store_true", help="stage a load-and-trace bundle without instructing any `/ysm export` flow")
+    capture.add_argument("--model-trace", action="store_true", help="enable the focused model-state trace lane in the staged headed wrapper")
+    capture.add_argument("--model-trace-sample", help="sample path/name substring that arms focused model tracing; defaults to the staged ysm filename")
+    capture.add_argument("--model-trace-families", help="comma-separated bone/family tokens to highlight in model-trace scans")
+    capture.add_argument("--model-trace-export-filter", default="main.json", help="export json basename to treat as the main model truth target")
+    capture.add_argument("--model-trace-rel", default="0x4e2c80", help="inline-hook rel target for the focused model trace lane")
+    capture.add_argument("--model-trace-patch-len", type=int, default=16, help="patch length for the focused model trace hook")
+    capture.add_argument("--model-trace-limit", type=int, default=32, help="budget of focused model-trace invocations")
+    capture.add_argument("--model-trace-scan-bytes", default="0x240", help="bytes to scan per candidate object during model trace")
+    capture.add_argument("--model-trace-string-limit", type=int, default=64, help="max string observations per model-trace object")
+    capture.add_argument("--model-trace-vector-limit", type=int, default=48, help="max float3 observations per model-trace object")
+
+    summarize = sub.add_parser("summarize-model-trace", help="summarize structured model-trace observations and optional snapshot bones")
+    summarize.add_argument("intercept_log", type=Path, help="headed-host intercept log to analyze")
+    summarize.add_argument("--snapshot-root", type=Path, help="optional official snapshot root to join with model-trace observations")
+    summarize.add_argument("--model-name", default="main.json", help="canonical model json name to summarize from the snapshot")
+    summarize.add_argument("--family-filter", help="optional comma-separated bone/family tokens to keep")
+    summarize.add_argument("--json", action="store_true", help="print JSON instead of plain text")
+
+    audit = sub.add_parser("audit-runtime", help="audit required Forge/Minecraft runtime jars from ~/.minecraft")
+    audit.add_argument("--minecraft-root", type=Path, default=DEFAULT_MINECRAFT_ROOT, help="Minecraft runtime root")
+    audit.add_argument("--version-id", default=DEFAULT_FORGE_VERSION_ID, help="Forge version id to inspect")
+    audit.add_argument("--missing-class", action="append", default=[], help="missing class name to search for under libraries/mods")
+    audit.add_argument("--json", action="store_true", help="print machine-readable JSON")
+
+    args = ap.parse_args()
+    if args.cmd == "snapshot":
+        out = snapshot_official_export(
+            args.export_root,
+            out_dir=args.out_dir,
+            ysm_path=args.ysm_path,
+            official_jar=args.official_jar,
+        )
+        print(f"official_export_snapshot: {out}")
+        return 0
+
+    if args.cmd == "stage-vm":
+        out = stage_vm_bundle(
+            args.out_dir,
+            official_jar=args.official_jar,
+            sample_paths=args.sample,
+            launcher_command_file=args.launcher_command_file,
+            minecraft_root=args.minecraft_root,
+            version_id=args.version_id,
+        )
+        print(f"vm_bundle: {out}")
+        return 0
+
+    if args.cmd == "audit-runtime":
+        report = audit_minecraft_runtime(
+            args.minecraft_root,
+            version_id=args.version_id,
+            missing_classes=args.missing_class,
+        )
+        if args.json:
+            print(json.dumps(report, indent=2))
+            return 0
+        print(f"minecraft_root: {report['minecraft_root']}")
+        print(f"version_id: {report['version_id']}")
+        print(f"searched_version_ids: {', '.join(report['searched_version_ids'])}")
+        print(f"main_class: {report['main_class']}")
+        print(f"entry_count: {report['entry_count']}")
+        print(f"missing_count: {report['missing_count']}")
+        for item in report["missing"]:
+            print(f"missing: {item['kind']} {item['logical_name']} -> {item['relative_path']}")
+        for class_name, candidates in report.get("missing_class_candidates", {}).items():
+            print(f"class {class_name}: {', '.join(candidates) if candidates else '-'}")
+        return 0
+
+    if args.cmd == "stage-headed-host":
+        model_trace = HeadedModelTraceConfig(
+            enabled=args.model_trace,
+            sample_hint=args.model_trace_sample,
+            family_filter=_parse_model_trace_family_filter(args.model_trace_families),
+            export_filter=args.model_trace_export_filter,
+            trace_rel=int(args.model_trace_rel, 0),
+            patch_len=args.model_trace_patch_len,
+            budget=args.model_trace_limit,
+            scan_bytes=int(args.model_trace_scan_bytes, 0),
+            string_limit=args.model_trace_string_limit,
+            vector_limit=args.model_trace_vector_limit,
+        )
+        out = stage_headed_host_bundle(
+            args.out_dir,
+            minecraft_root=args.minecraft_root,
+            version_id=args.version_id,
+            launcher_profiles=args.launcher_profiles,
+            profile_id=args.profile_id,
+            profile_name=args.profile_name,
+            model_trace=model_trace,
+        )
+        print(f"headed_host_bundle: {out}")
+        return 0
+
+    if args.cmd == "capture-legacy-export":
+        model_trace = HeadedModelTraceConfig(
+            enabled=args.model_trace,
+            sample_hint=args.model_trace_sample,
+            family_filter=_parse_model_trace_family_filter(args.model_trace_families),
+            export_filter=args.model_trace_export_filter,
+            trace_rel=int(args.model_trace_rel, 0),
+            patch_len=args.model_trace_patch_len,
+            budget=args.model_trace_limit,
+            scan_bytes=int(args.model_trace_scan_bytes, 0),
+            string_limit=args.model_trace_string_limit,
+            vector_limit=args.model_trace_vector_limit,
+        )
+        capture = capture_legacy_export(
+            args.ysm_path,
+            out_dir=args.out_dir,
+            minecraft_root=args.minecraft_root,
+            version_id=args.version_id,
+            launcher_profiles=args.launcher_profiles,
+            profile_id=args.profile_id,
+            profile_name=args.profile_name,
+            model_id=args.model_id,
+            extra=args.extra,
+            export_root=args.export_root,
+            snapshot_dir=args.snapshot_dir,
+            keep_existing=args.keep_existing,
+            model_trace=model_trace,
+            trace_only=args.trace_only,
+        )
+        manifest = json.loads(capture.manifest_path.read_text(encoding="utf-8"))
+        print(f"legacy_capture_bundle: {capture.bundle_root}")
+        print(f"staged_sample: {capture.sample_copy}")
+        print(f"raw_export_root: {capture.export_root}")
+        if manifest["suggested_export_command"] is not None:
+            print(f"suggested_export_command: {manifest['suggested_export_command']}")
+        else:
+            print("suggested_export_command: none (trace-only load path)")
+            print(f"trace_log: {capture.bundle_root / 'trace' / 'ysm262_intercept.log'}")
+        if manifest["selected_export_root"] is not None:
+            print(f"selected_export_root: {manifest['selected_export_root']}")
+        if manifest["official_snapshot_root"] is not None:
+            print(f"official_export_snapshot: {manifest['official_snapshot_root']}")
+        else:
+            print("official_export_snapshot: pending")
+        if manifest["verify_command"] is not None:
+            print(f"verify_command: {manifest['verify_command']}")
+        print(f"capture_manifest: {capture.manifest_path}")
+        return 0
+
+    if args.cmd == "summarize-model-trace":
+        summary = summarize_model_trace(
+            args.intercept_log,
+            snapshot_root=args.snapshot_root,
+            family_filter=_parse_model_trace_family_filter(args.family_filter),
+            model_name=args.model_name,
+        )
+        if args.json:
+            print(json.dumps(summary, indent=2))
+            return 0
+        print(f"intercept_log: {summary['intercept_log']}")
+        print(f"snapshot_root: {summary['snapshot_root']}")
+        print(f"model_name: {summary['model_name']}")
+        print(f"event_count: {len(summary['events'])}")
+        for item in summary["events"]:
+            print(f"event: {item}")
+        print(f"object_count: {len(summary['objects'])}")
+        for label, payload in summary["objects"].items():
+            string_count = len(payload["strings"])
+            ptr_string_count = len(payload["ptr_strings"])
+            float_count = len(payload["float3"])
+            print(f"object: {label} strings={string_count} ptr_strings={ptr_string_count} float3={float_count}")
+        if summary["candidate_hook_rels"]:
+            print(f"candidate_hook_rel_count: {len(summary['candidate_hook_rels'])}")
+            for item in summary["candidate_hook_rels"][:20]:
+                print(f"candidate_hook_rel: {item['rel']} hits={item['hits']}")
+        if summary["bone_summaries"]:
+            print(f"bone_count: {len(summary['bone_summaries'])}")
+            for bone in summary["bone_summaries"][:40]:
+                print(
+                    f"bone: {bone['name']} parent={bone['parent']} pivot={bone['pivot']} cubes={bone['cube_count']} trace_hits={len(bone['matching_trace_labels'])}"
+                )
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/extractors/ysm_extract.py
+++ b/tools/ysm_extractor/extractors/ysm_extract.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from extractors.bom_v3_end_to_end_parser import decode_bom_v3, export_or_restore_bom_v3_assets
+from extractors.ysm262_oracle import (
+    DEFAULT_FORGE_VERSION_ID,
+    DEFAULT_HEADED_DEBUG_PROFILE_ID,
+    DEFAULT_HEADED_DEBUG_PROFILE_NAME,
+    DEFAULT_MINECRAFT_ROOT,
+    HeadedModelTraceConfig,
+    capture_legacy_export,
+    summarize_model_trace,
+    _parse_model_trace_family_filter,
+    snapshot_official_export,
+    stage_headed_host_bundle,
+)
+from extractors.ysgp_compact_v2_parser import extract_entry_payloads, parse_compact_v2_file
+from ysgp_outer_v3_static import MAGIC_PREFIX
+
+
+def _sanitize_name(name: str) -> str:
+    out: list[str] = []
+    for ch in name:
+        if ch.isalnum() or ch in ("-", "_", "."):
+            out.append(ch)
+        else:
+            out.append("_")
+    return "".join(out) or "entry"
+
+
+def _format_family(codec_format: int | None) -> str:
+    if codec_format == 31:
+        return "modern_31"
+    if codec_format in (1, 9, 15):
+        return "legacy_1_9_15"
+    if codec_format is None:
+        return "unknown"
+    return f"unsupported_{codec_format}"
+
+
+def _detect_container(data: bytes) -> tuple[str, int | None]:
+    if data.startswith(MAGIC_PREFIX):
+        return ("bom_v3", 3)
+    if data[:4] == b"YSGP" and len(data) >= 8:
+        ver_be = int.from_bytes(data[4:8], "big")
+        return ("compact_ysgp", ver_be)
+    return ("unknown", None)
+
+
+def _handle_bom_v3(path: Path, args: argparse.Namespace) -> None:
+    result = decode_bom_v3(path)
+    exported_dir: Path | None = None
+
+    print(f"file: {path}")
+    print("container: bom_v3")
+    print(f"codec_format: {result.codec_format}")
+    print(f"format_family: {_format_family(result.codec_format)}")
+    print(f"prelude_skip: {result.prelude_skip}")
+    print(f"wrapped_offset: 0x{result.wrapped_offset:x}")
+    print(f"transcoded_zst_len: 0x{len(result.transcoded_zst):x}")
+    print(f"decoded_len: 0x{len(result.decompressed):x}")
+    print(f"decoded_head64: {result.decompressed[:64].hex()}")
+
+    if args.dump_zst:
+        zst_path = path.with_name(f"{path.stem}.transcoded.zst")
+        zst_path.write_bytes(result.transcoded_zst)
+        print(f"dump_zst: {zst_path}")
+
+    if args.dump_decoded:
+        decoded_path = path.with_name(f"{path.stem}.decoded.bin")
+        decoded_path.write_bytes(result.decompressed)
+        print(f"dump_decoded: {decoded_path}")
+
+    if args.scan_assets or args.dump_assets or args.dump_folder or args.source_oracle is not None:
+        exported_dir, source_oracle_path, oracle = export_or_restore_bom_v3_assets(
+            path,
+            result.codec_format,
+            scan_assets=args.scan_assets,
+            dump_assets=args.dump_assets,
+            dump_folder=args.dump_folder,
+            debug=args.debug,
+            source_oracle=args.source_oracle,
+            legacy_auto_source_oracle=args.auto_source_oracle,
+        )
+        if exported_dir is not None:
+            print(f"dump_folder: {exported_dir}")
+        if oracle is not None and source_oracle_path is not None:
+            if args.source_oracle is not None:
+                print(f"source_oracle_restore: {oracle.out_dir}")
+            else:
+                print(f"source_oracle_auto: {source_oracle_path} ({oracle.match_count}/{oracle.asset_count})")
+                print(f"source_oracle_restore: {oracle.out_dir}")
+            print(f"source_oracle_match: {oracle.match_count}/{oracle.asset_count}")
+            print(f"exact_restore_complete: {str(oracle.exact_complete).lower()}")
+
+
+def _dump_compact_entries(path: Path, dump_entries: bool) -> None:
+    container = parse_compact_v2_file(path)
+    print(f"file: {path}")
+    print("container: compact_v2")
+    print(f"version_be: {container.version_be}")
+    print(f"header_md5_16: {container.header_md5_16.hex()}")
+    print(f"header_md5_verified: {container.header_md5_verified}")
+    print(f"entry_count: {len(container.entries)}")
+
+    for entry, payload, key in extract_entry_payloads(container):
+        if entry.name_decoded is not None:
+            name = entry.name_decoded
+        else:
+            try:
+                name = base64.b64decode(entry.name_b64, validate=False).decode("utf-8", "replace")
+            except Exception:
+                name = entry.name_b64.decode("ascii", "replace")
+        print(
+            f"entry[{entry.index}]: off=0x{entry.entry_offset:x} id={entry.entry_id.hex()} "
+            f"name={name!r} payload_len=0x{entry.payload_len:x} key_len=0x{entry.key_len:x}"
+        )
+
+        if dump_entries:
+            base_name = _sanitize_name(name)
+            payload_path = path.with_name(f"{path.stem}.entry_{entry.index:02d}.{base_name}.payload.bin")
+            key_path = path.with_name(f"{path.stem}.entry_{entry.index:02d}.{base_name}.key.bin")
+            payload_path.write_bytes(payload)
+            key_path.write_bytes(key)
+            print(f"entry[{entry.index}].payload_dump: {payload_path}")
+            print(f"entry[{entry.index}].key_dump: {key_path}")
+
+
+def _handle_compact(path: Path, version_be: int, args: argparse.Namespace) -> None:
+    if version_be == 2:
+        _dump_compact_entries(path, dump_entries=args.dump_entries)
+        return
+    if version_be == 1:
+        print(f"file: {path}")
+        print("container: compact_v1")
+        print("status: detected but not yet integrated in this unified extractor")
+        return
+    print(f"file: {path}")
+    print(f"container: compact_ysgp(version={version_be})")
+    print("status: unsupported")
+
+
+def _iter_inputs(paths: Iterable[str]) -> Iterable[Path]:
+    for p in paths:
+        yield Path(p)
+
+
+def _interactive_banner() -> str:
+    return "\n".join(
+        (
+            "YSM Extract",
+            "-----------",
+            "Mode: heuristic extractor output, not official/native export parity.",
+            "For official export capture use: capture-legacy-export <sample.ysm>",
+            "Toggle options, then run extraction.",
+            "Commands: number=toggle  s=source oracle path  r=run  q=quit",
+        )
+    )
+
+
+def _interactive_option_rows(args: argparse.Namespace) -> list[tuple[str, str, str]]:
+    return [
+        ("1", "dump_folder", "Export canonical asset folder"),
+        ("2", "scan_assets", "Scan decoded payload for assets"),
+        ("3", "dump_assets", "Dump discovered assets"),
+        ("4", "dump_decoded", "Dump fully decoded payload"),
+        ("5", "dump_zst", "Dump transcoded zstd stream"),
+        ("6", "debug", "Keep debug artifacts"),
+        ("7", "dump_entries", "Compact v2: dump per-entry payload/key blobs"),
+        ("8", "auto_source_oracle", "Auto source-oracle restore for legacy 1/9/15"),
+    ]
+
+
+def _print_interactive_menu(args: argparse.Namespace) -> None:
+    print(_interactive_banner())
+    for key, attr, label in _interactive_option_rows(args):
+        mark = "x" if bool(getattr(args, attr)) else " "
+        print(f" {key}. [{mark}] {label}")
+    src = str(args.source_oracle) if args.source_oracle is not None else "(auto/off)"
+    print(f" s.     Source oracle path: {src}")
+
+
+def _prompt_paths() -> list[str]:
+    while True:
+        raw = input("YSM path(s): ").strip()
+        if not raw:
+            print("Enter at least one file path.")
+            continue
+        parts = shlex.split(raw)
+        if not parts:
+            print("Enter at least one file path.")
+            continue
+        return parts
+
+
+def _interactive_args(base_args: argparse.Namespace) -> argparse.Namespace:
+    args = argparse.Namespace(**vars(base_args))
+    if not args.dump_folder and not args.scan_assets and not args.dump_assets and not args.dump_entries:
+        args.dump_folder = True
+    while True:
+        print()
+        _print_interactive_menu(args)
+        choice = input("Select option: ").strip().lower()
+        if choice in {"q", "quit", "exit"}:
+            raise SystemExit(0)
+        if choice in {"r", "run", ""}:
+            args.inputs = _prompt_paths()
+            return args
+        if choice == "s":
+            raw = input("Source oracle path (empty to clear): ").strip()
+            args.source_oracle = Path(raw).expanduser() if raw else None
+            continue
+        toggles = {key: attr for key, attr, _label in _interactive_option_rows(args)}
+        attr = toggles.get(choice)
+        if attr is None:
+            print("Unknown selection.")
+            continue
+        setattr(args, attr, not bool(getattr(args, attr)))
+        if attr == "auto_source_oracle" and args.auto_source_oracle and args.source_oracle is not None:
+            # manual path still wins; leave it set
+            pass
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        description="Unified YSM extractor entrypoint for BOM v3 (formats 1/9/15/31) and compact YSGP v2.",
+        epilog=(
+            "Bare input extraction and interactive mode use the heuristic Python extractor, which can differ from "
+            "official YSM export output for legacy files.\n\n"
+            "Utility commands:\n"
+            "  snapshot <official-export-root>\n"
+            "  stage-headed-host --out-dir <bundle-dir>\n"
+            "  capture-legacy-export <sample.ysm> [options]\n"
+            "  summarize-model-trace <intercept.log> [options]"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("inputs", nargs="*", help="Input YSM/YSGP files")
+    ap.add_argument("--interactive", action="store_true", help="launch interactive menu mode")
+
+    ap.add_argument("--dump-zst", action="store_true", help="BOM v3: dump transcoded zstd stream")
+    ap.add_argument("--dump-decoded", action="store_true", help="BOM v3: dump fully decoded payload")
+    ap.add_argument("--scan-assets", action="store_true", help="BOM v3: scan decoded payload for assets")
+    ap.add_argument("--dump-assets", action="store_true", help="BOM v3: dump discovered assets")
+    ap.add_argument("--dump-folder", action="store_true", help="BOM v3: export canonical asset folder")
+    ap.add_argument("--debug", action="store_true", help="keep debug artifacts like section bins, manifests, decompiled stubs, and heuristic fallbacks")
+
+    ap.add_argument(
+        "--source-oracle",
+        type=Path,
+        help="BOM v3: restore exact files from this source folder or zip archive",
+    )
+    ap.add_argument(
+        "--no-auto-source-oracle",
+        action="store_true",
+        help="Legacy 1/9/15: disable automatic nearby source-oracle lookup",
+    )
+
+    ap.add_argument(
+        "--dump-entries",
+        action="store_true",
+        help="Compact v2: dump per-entry payload/key blobs",
+    )
+    return ap
+
+
+def build_command_argparser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        description="YSM extractor utility commands for native-truth legacy export capture and snapshotting."
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    snap = sub.add_parser("snapshot", help="normalize an official export folder into a canonical snapshot")
+    snap.add_argument("export_root", type=Path, help="official export folder to snapshot")
+    snap.add_argument("--out-dir", type=Path, help="output folder for the normalized snapshot")
+    snap.add_argument("--ysm-path", type=Path, help="optional source .ysm path for naming/manifest context")
+    snap.add_argument("--official-jar", type=Path, help="override the 2.6.2 official jar path")
+
+    headed = sub.add_parser("stage-headed-host", help="stage a headed host debug bundle for the real Forge client")
+    headed.add_argument(
+        "--out-dir",
+        type=Path,
+        help="bundle output directory; defaults to ROOT/debug_runtime/headed_host_bundle or $YSM262_DEBUG_RUNTIME_ROOT/headed_host_bundle",
+    )
+    headed.add_argument("--minecraft-root", type=Path, default=DEFAULT_MINECRAFT_ROOT, help="Minecraft runtime root to mirror")
+    headed.add_argument("--version-id", default=DEFAULT_FORGE_VERSION_ID, help="Forge version id for the dedicated launcher profile")
+    headed.add_argument(
+        "--launcher-profiles",
+        type=Path,
+        default=DEFAULT_MINECRAFT_ROOT / "launcher_profiles.json",
+        help="launcher_profiles.json to inspect when preparing the profile payload",
+    )
+    headed.add_argument("--profile-id", default=DEFAULT_HEADED_DEBUG_PROFILE_ID, help="launcher profile id to create/update")
+    headed.add_argument("--profile-name", default=DEFAULT_HEADED_DEBUG_PROFILE_NAME, help="launcher profile display name")
+    headed.add_argument("--model-trace", action="store_true", help="enable the focused model-state trace lane in the headed wrapper")
+    headed.add_argument("--model-trace-sample", help="sample path/name substring that arms focused model tracing")
+    headed.add_argument("--model-trace-families", help="comma-separated bone/family tokens to highlight in model-trace scans")
+    headed.add_argument("--model-trace-export-filter", default="main.json", help="export json basename to treat as the main model truth target")
+    headed.add_argument("--model-trace-rel", default="0x4e2c80", help="inline-hook rel target for the focused model trace lane")
+    headed.add_argument("--model-trace-patch-len", type=int, default=16, help="patch length for the focused model trace hook")
+    headed.add_argument("--model-trace-limit", type=int, default=32, help="budget of focused model-trace invocations")
+    headed.add_argument("--model-trace-scan-bytes", default="0x240", help="bytes to scan per candidate object during model trace")
+    headed.add_argument("--model-trace-string-limit", type=int, default=64, help="max string observations per model-trace object")
+    headed.add_argument("--model-trace-vector-limit", type=int, default=48, help="max float3 observations per model-trace object")
+
+    capture = sub.add_parser(
+        "capture-legacy-export",
+        help="stage one legacy .ysm into the headed client path for trace and optional export/snapshot capture",
+    )
+    capture.add_argument("ysm_path", type=Path, help="legacy .ysm sample to stage")
+    capture.add_argument("--out-dir", type=Path, help="capture bundle output directory")
+    capture.add_argument("--minecraft-root", type=Path, default=DEFAULT_MINECRAFT_ROOT, help="Minecraft runtime root to mirror")
+    capture.add_argument("--version-id", default=DEFAULT_FORGE_VERSION_ID, help="Forge version id for the dedicated launcher profile")
+    capture.add_argument(
+        "--launcher-profiles",
+        type=Path,
+        default=DEFAULT_MINECRAFT_ROOT / "launcher_profiles.json",
+        help="launcher_profiles.json to inspect when preparing the profile payload",
+    )
+    capture.add_argument("--profile-id", help="launcher profile id to create/update")
+    capture.add_argument("--profile-name", help="launcher profile display name")
+    capture.add_argument("--model-id", help="override the imported model id used by `/ysm export`")
+    capture.add_argument("--extra", help="optional extra argument string to append to `/ysm export <model_id>`")
+    capture.add_argument("--export-root", type=Path, help="override the raw official export root to harvest")
+    capture.add_argument("--snapshot-dir", type=Path, help="output folder for the canonical official snapshot")
+    capture.add_argument("--keep-existing", action="store_true", help="do not clear staged custom/export state before preparing the capture")
+    capture.add_argument("--trace-only", action="store_true", help="stage a load-and-trace bundle without instructing any `/ysm export` flow")
+    capture.add_argument("--model-trace", action="store_true", help="enable the focused model-state trace lane in the staged headed wrapper")
+    capture.add_argument("--model-trace-sample", help="sample path/name substring that arms focused model tracing; defaults to the staged ysm filename")
+    capture.add_argument("--model-trace-families", help="comma-separated bone/family tokens to highlight in model-trace scans")
+    capture.add_argument("--model-trace-export-filter", default="main.json", help="export json basename to treat as the main model truth target")
+    capture.add_argument("--model-trace-rel", default="0x4e2c80", help="inline-hook rel target for the focused model trace lane")
+    capture.add_argument("--model-trace-patch-len", type=int, default=16, help="patch length for the focused model trace hook")
+    capture.add_argument("--model-trace-limit", type=int, default=32, help="budget of focused model-trace invocations")
+    capture.add_argument("--model-trace-scan-bytes", default="0x240", help="bytes to scan per candidate object during model trace")
+    capture.add_argument("--model-trace-string-limit", type=int, default=64, help="max string observations per model-trace object")
+    capture.add_argument("--model-trace-vector-limit", type=int, default=48, help="max float3 observations per model-trace object")
+
+    summarize = sub.add_parser("summarize-model-trace", help="summarize structured model-trace observations and optional snapshot bones")
+    summarize.add_argument("intercept_log", type=Path, help="headed-host intercept log to analyze")
+    summarize.add_argument("--snapshot-root", type=Path, help="optional official snapshot root to join with model-trace observations")
+    summarize.add_argument("--model-name", default="main.json", help="canonical model json name to summarize from the snapshot")
+    summarize.add_argument("--family-filter", help="optional comma-separated bone/family tokens to keep")
+    summarize.add_argument("--json", action="store_true", help="print JSON instead of plain text")
+    return ap
+
+
+def _run_command(args: argparse.Namespace) -> int:
+    if args.cmd == "snapshot":
+        out = snapshot_official_export(
+            args.export_root,
+            out_dir=args.out_dir,
+            ysm_path=args.ysm_path,
+            official_jar=args.official_jar,
+        )
+        print(f"official_export_snapshot: {out}")
+        return 0
+
+    if args.cmd == "stage-headed-host":
+        model_trace = HeadedModelTraceConfig(
+            enabled=args.model_trace,
+            sample_hint=args.model_trace_sample,
+            family_filter=_parse_model_trace_family_filter(args.model_trace_families),
+            export_filter=args.model_trace_export_filter,
+            trace_rel=int(args.model_trace_rel, 0),
+            patch_len=args.model_trace_patch_len,
+            budget=args.model_trace_limit,
+            scan_bytes=int(args.model_trace_scan_bytes, 0),
+            string_limit=args.model_trace_string_limit,
+            vector_limit=args.model_trace_vector_limit,
+        )
+        out = stage_headed_host_bundle(
+            args.out_dir,
+            minecraft_root=args.minecraft_root,
+            version_id=args.version_id,
+            launcher_profiles=args.launcher_profiles,
+            profile_id=args.profile_id,
+            profile_name=args.profile_name,
+            model_trace=model_trace,
+        )
+        print(f"headed_host_bundle: {out}")
+        return 0
+
+    if args.cmd == "summarize-model-trace":
+        summary = summarize_model_trace(
+            args.intercept_log,
+            snapshot_root=args.snapshot_root,
+            family_filter=_parse_model_trace_family_filter(args.family_filter),
+            model_name=args.model_name,
+        )
+        if args.json:
+            print(json.dumps(summary, indent=2))
+            return 0
+        print(f"intercept_log: {summary['intercept_log']}")
+        print(f"snapshot_root: {summary['snapshot_root']}")
+        print(f"model_name: {summary['model_name']}")
+        print(f"event_count: {len(summary['events'])}")
+        for item in summary["events"]:
+            print(f"event: {item}")
+        print(f"object_count: {len(summary['objects'])}")
+        for label, payload in summary["objects"].items():
+            print(
+                f"object: {label} strings={len(payload['strings'])} ptr_strings={len(payload['ptr_strings'])} float3={len(payload['float3'])}"
+            )
+        if summary["candidate_hook_rels"]:
+            print(f"candidate_hook_rel_count: {len(summary['candidate_hook_rels'])}")
+            for item in summary["candidate_hook_rels"][:20]:
+                print(f"candidate_hook_rel: {item['rel']} hits={item['hits']}")
+        if summary["bone_summaries"]:
+            print(f"bone_count: {len(summary['bone_summaries'])}")
+            for bone in summary["bone_summaries"][:40]:
+                print(
+                    f"bone: {bone['name']} parent={bone['parent']} pivot={bone['pivot']} cubes={bone['cube_count']} trace_hits={len(bone['matching_trace_labels'])}"
+                )
+        return 0
+
+    model_trace = HeadedModelTraceConfig(
+        enabled=args.model_trace,
+        sample_hint=args.model_trace_sample,
+        family_filter=_parse_model_trace_family_filter(args.model_trace_families),
+        export_filter=args.model_trace_export_filter,
+        trace_rel=int(args.model_trace_rel, 0),
+        patch_len=args.model_trace_patch_len,
+        budget=args.model_trace_limit,
+        scan_bytes=int(args.model_trace_scan_bytes, 0),
+        string_limit=args.model_trace_string_limit,
+        vector_limit=args.model_trace_vector_limit,
+    )
+    capture = capture_legacy_export(
+        args.ysm_path,
+        out_dir=args.out_dir,
+        minecraft_root=args.minecraft_root,
+        version_id=args.version_id,
+        launcher_profiles=args.launcher_profiles,
+        profile_id=args.profile_id,
+        profile_name=args.profile_name,
+        model_id=args.model_id,
+        extra=args.extra,
+        export_root=args.export_root,
+        snapshot_dir=args.snapshot_dir,
+        keep_existing=args.keep_existing,
+        model_trace=model_trace,
+        trace_only=args.trace_only,
+    )
+    manifest = json.loads(capture.manifest_path.read_text(encoding="utf-8"))
+    print(f"legacy_capture_bundle: {capture.bundle_root}")
+    print(f"staged_sample: {capture.sample_copy}")
+    print(f"raw_export_root: {capture.export_root}")
+    if manifest["suggested_export_command"] is not None:
+        print(f"suggested_export_command: {manifest['suggested_export_command']}")
+    else:
+        print("suggested_export_command: none (trace-only load path)")
+        print(f"trace_log: {capture.bundle_root / 'trace' / 'ysm262_intercept.log'}")
+    if manifest["selected_export_root"] is not None:
+        print(f"selected_export_root: {manifest['selected_export_root']}")
+    if manifest["official_snapshot_root"] is not None:
+        print(f"official_export_snapshot: {manifest['official_snapshot_root']}")
+    else:
+        print("official_export_snapshot: pending")
+    if manifest["verify_command"] is not None:
+        print(f"verify_command: {manifest['verify_command']}")
+    print(f"capture_manifest: {capture.manifest_path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv and argv[0] in {"snapshot", "stage-headed-host", "capture-legacy-export", "summarize-model-trace"}:
+        args = build_command_argparser().parse_args(argv)
+        return _run_command(args)
+
+    args = build_argparser().parse_args(argv)
+    args.auto_source_oracle = not args.no_auto_source_oracle
+    if args.interactive or not args.inputs:
+        if not sys.stdin.isatty():
+            raise SystemExit("interactive mode requires a TTY")
+        print("note: interactive mode uses the heuristic Python extractor.")
+        print("note: for official/native legacy export capture use `capture-legacy-export <sample.ysm>`.")
+        args = _interactive_args(args)
+
+    for i, path in enumerate(_iter_inputs(args.inputs)):
+        if i:
+            print()
+        path = Path(os.path.expanduser(str(path)))
+        data = path.read_bytes()
+        kind, ver = _detect_container(data)
+        if kind == "bom_v3":
+            _handle_bom_v3(path, args)
+            continue
+        if kind == "compact_ysgp" and ver is not None:
+            _handle_compact(path, ver, args)
+            continue
+        print(f"file: {path}")
+        print("container: unknown")
+        print("status: unsupported")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/extractors/ysm_extractor.py
+++ b/tools/ysm_extractor/extractors/ysm_extractor.py
@@ -1,0 +1,5 @@
+from extractors.ysm_extract import *  # noqa: F401,F403
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/extractors/ysm_legacy_native_lift.py
+++ b/tools/ysm_extractor/extractors/ysm_legacy_native_lift.py
@@ -1,0 +1,577 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from bom_v3_legacy_sections import dump_legacy_sections, scan_legacy_sections
+from extractors.bom_v3_end_to_end_parser import decode_bom_v3
+from extractors.bom_v3_payload_assets import (
+    _read_property_name,
+    _sanitize_name,
+    parse_property_assets,
+)
+from extractors.legacy_asset_inventory import (
+    build_legacy_declared_export_inventory,
+    canonical_legacy_export_name,
+    legacy_asset_category,
+)
+from extractors.bom_v3_source_oracle import find_best_source_oracle, restore_from_source_oracle
+from extractors.ysgp_container_scanner import scan_file
+from extractors.ysm262_oracle import snapshot_official_export
+
+
+NATIVE_DISPATCH_CHAIN = (
+    "0x5190e0 FUN_005190e0 inner decoded-section parser/dispatcher",
+    "0x526ce0 FUN_00526ce0 legacy intermediate schema loader",
+    "0x520500 FUN_00520500 shared low-format builder/materializer",
+)
+
+@dataclass(frozen=True)
+class LegacyNativeAssetSpec:
+    ordinal: int
+    tag: str
+    label: str
+    hash_hex: str
+    category: str
+    family: str
+    export_name: str
+
+
+@dataclass(frozen=True)
+class LegacySanityIssue:
+    severity: str
+    path: str
+    message: str
+
+
+@dataclass(frozen=True)
+class LegacyNativeState:
+    path: Path
+    property_name: str | None
+    codec_format: int
+    decoded_len: int
+    generic_families: tuple[str, ...]
+    has_arrow_family: bool
+    has_sound_resource: bool
+    expected_model_files: tuple[str, ...]
+    expected_animation_files: tuple[str, ...]
+    expected_texture_files: tuple[str, ...]
+    expected_sound_files: tuple[str, ...]
+    expected_texture_count: int
+    expected_sound_count: int
+    assets: tuple[LegacyNativeAssetSpec, ...]
+    native_dispatch_chain: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LegacyNativeExportResult:
+    out_dir: Path
+    state: LegacyNativeState
+    materialization_backend: str
+    source_root: Path | None
+    official_export_root: Path | None
+    source_match_count: int
+    source_asset_count: int
+    sanity_issues: tuple[LegacySanityIssue, ...]
+
+
+def _default_out_dir(ysm_path: Path, codec_format: int) -> Path:
+    folder_name = _sanitize_name(_read_property_name(ysm_path) or ysm_path.stem)
+    return ysm_path.with_name(f"{folder_name}_native_lift_format{codec_format}")
+
+
+def _state_from_assets(ysm_path: Path) -> LegacyNativeState:
+    result = decode_bom_v3(ysm_path)
+    codec_format = result.codec_format
+    if codec_format not in (1, 9, 15):
+        raise RuntimeError(f"legacy native lift only supports formats 1, 9, and 15; got {codec_format!r}")
+
+    assets = parse_property_assets(scan_file(ysm_path, dump=False).property_text)
+    inventory = build_legacy_declared_export_inventory(tuple(assets), codec_format)
+    asset_specs = tuple(
+        LegacyNativeAssetSpec(
+            ordinal=asset.ordinal,
+            tag=asset.tag,
+            label=asset.label,
+            hash_hex=asset.hash_hex,
+            category=legacy_asset_category(asset.tag)[0],
+            family=legacy_asset_category(asset.tag)[1],
+            export_name=canonical_legacy_export_name(asset.tag, asset.label, codec_format),
+        )
+        for asset in assets
+    )
+    texture_count = len(inventory.texture_files)
+    sound_count = len(inventory.sound_files)
+    has_arrow_family = any(asset.family == "arrow" for asset in asset_specs)
+    return LegacyNativeState(
+        path=ysm_path,
+        property_name=_read_property_name(ysm_path),
+        codec_format=codec_format,
+        decoded_len=len(result.decompressed),
+        generic_families=("main", "arm"),
+        has_arrow_family=has_arrow_family,
+        has_sound_resource=sound_count > 0,
+        expected_model_files=inventory.model_files,
+        expected_animation_files=inventory.animation_files,
+        expected_texture_files=inventory.texture_files,
+        expected_sound_files=inventory.sound_files,
+        expected_texture_count=texture_count,
+        expected_sound_count=sound_count,
+        assets=asset_specs,
+        native_dispatch_chain=NATIVE_DISPATCH_CHAIN,
+    )
+
+
+def parse_legacy_native_state(path: Path) -> LegacyNativeState:
+    return _state_from_assets(path.resolve())
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _iter_model_bones(path: Path) -> list[dict[str, Any]]:
+    obj = _load_json(path)
+    if not isinstance(obj, dict):
+        return []
+    geometry = obj.get("minecraft:geometry")
+    if not isinstance(geometry, list):
+        return []
+    for geom in geometry:
+        if not isinstance(geom, dict):
+            continue
+        bones = geom.get("bones")
+        if isinstance(bones, list):
+            return [bone for bone in bones if isinstance(bone, dict)]
+    return []
+
+
+def _vector_has_nonfinite(values: Any) -> bool:
+    if not isinstance(values, list):
+        return False
+    for value in values:
+        if not isinstance(value, (int, float)):
+            continue
+        if not math.isfinite(float(value)):
+            return True
+    return False
+
+
+def _run_sanity_checks(state: LegacyNativeState, out_dir: Path) -> tuple[LegacySanityIssue, ...]:
+    issues: list[LegacySanityIssue] = []
+    for file_name in state.expected_model_files:
+        path = out_dir / file_name
+        if not path.exists():
+            issues.append(LegacySanityIssue("error", file_name, "missing expected model output"))
+            continue
+        try:
+            bones = _iter_model_bones(path)
+        except Exception as exc:
+            issues.append(LegacySanityIssue("error", file_name, f"unreadable model json: {exc}"))
+            continue
+        for bone in bones:
+            bone_name = str(bone.get("name", "<unnamed>"))
+            pivot = bone.get("pivot")
+            if _vector_has_nonfinite(pivot):
+                issues.append(LegacySanityIssue("error", file_name, f"{bone_name}: non-finite pivot"))
+            if isinstance(pivot, list) and len(pivot) >= 2:
+                try:
+                    if abs(float(pivot[1])) > 128.0:
+                        issues.append(
+                            LegacySanityIssue(
+                                "warning",
+                                file_name,
+                                f"{bone_name}: suspicious pivot Y {float(pivot[1]):.3f}",
+                            )
+                        )
+                except Exception:
+                    pass
+            cubes = bone.get("cubes")
+            if not isinstance(cubes, list):
+                continue
+            for index, cube in enumerate(cubes):
+                if not isinstance(cube, dict):
+                    continue
+                origin = cube.get("origin")
+                size = cube.get("size")
+                if _vector_has_nonfinite(origin):
+                    issues.append(LegacySanityIssue("error", file_name, f"{bone_name}: cube[{index}] non-finite origin"))
+                if _vector_has_nonfinite(size):
+                    issues.append(LegacySanityIssue("error", file_name, f"{bone_name}: cube[{index}] non-finite size"))
+                if isinstance(origin, list):
+                    try:
+                        if any(abs(float(v)) > 256.0 for v in origin[:3]):
+                            issues.append(
+                                LegacySanityIssue(
+                                    "warning",
+                                    file_name,
+                                    f"{bone_name}: cube[{index}] suspicious origin {origin[:3]}",
+                                )
+                            )
+                    except Exception:
+                        pass
+                if isinstance(size, list):
+                    try:
+                        if any(abs(float(v)) > 256.0 for v in size[:3]):
+                            issues.append(
+                                LegacySanityIssue(
+                                    "warning",
+                                    file_name,
+                                    f"{bone_name}: cube[{index}] suspicious size {size[:3]}",
+                                )
+                            )
+                    except Exception:
+                        pass
+
+    for file_name in state.expected_animation_files:
+        if not (out_dir / file_name).exists():
+            issues.append(LegacySanityIssue("error", file_name, "missing expected animation output"))
+    for file_name in state.expected_texture_files:
+        if not (out_dir / file_name).exists():
+            issues.append(LegacySanityIssue("error", file_name, "missing expected texture output"))
+    for file_name in state.expected_sound_files:
+        if not (out_dir / file_name).exists():
+            issues.append(LegacySanityIssue("error", file_name, "missing expected sound output"))
+    return tuple(issues)
+
+
+def _write_state_files(
+    out_dir: Path,
+    state: LegacyNativeState,
+    *,
+    materialization_backend: str | None = None,
+    used_source_oracle: bool | None = None,
+    semantic_stage: str | None = None,
+    record_family_counts: dict[str, int] | None = None,
+    builder_family_counts: dict[str, int] | None = None,
+    source_root: Path | None = None,
+    official_export_root: Path | None = None,
+    source_match_count: int = 0,
+    source_asset_count: int = 0,
+    sanity_issues: tuple[LegacySanityIssue, ...] = (),
+) -> None:
+    state_manifest = {
+        "path": str(state.path),
+        "property_name": state.property_name,
+        "codec_format": state.codec_format,
+        "decoded_len": state.decoded_len,
+        "generic_families": list(state.generic_families),
+        "has_arrow_family": state.has_arrow_family,
+        "has_sound_resource": state.has_sound_resource,
+        "expected_model_files": list(state.expected_model_files),
+        "expected_animation_files": list(state.expected_animation_files),
+        "expected_texture_files": list(state.expected_texture_files),
+        "expected_sound_files": list(state.expected_sound_files),
+        "expected_texture_count": state.expected_texture_count,
+        "expected_sound_count": state.expected_sound_count,
+        "native_dispatch_chain": list(state.native_dispatch_chain),
+        "assets": [asdict(asset) for asset in state.assets],
+    }
+    (out_dir / "native_lift_state.json").write_text(json.dumps(state_manifest, indent=2), encoding="utf-8")
+    manifest = {
+        "source_file": str(state.path),
+        "property_name": state.property_name,
+        "codec_format": state.codec_format,
+        "materialization_backend": materialization_backend,
+        "used_source_oracle": used_source_oracle,
+        "semantic_stage": semantic_stage,
+        "record_family_counts": record_family_counts or {},
+        "builder_family_counts": builder_family_counts or {},
+        "source_root": str(source_root) if source_root is not None else None,
+        "official_export_root": str(official_export_root) if official_export_root is not None else None,
+        "source_match_count": source_match_count,
+        "source_asset_count": source_asset_count,
+        "sanity_issue_count": len(sanity_issues),
+        "error_level_sanity_count": sum(1 for item in sanity_issues if item.severity == "error"),
+        "warning_level_sanity_count": sum(1 for item in sanity_issues if item.severity == "warning"),
+        "sanity_issues": [asdict(item) for item in sanity_issues],
+    }
+    (out_dir / "native_lift_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def _record_family_counts(scan) -> dict[str, int]:
+    counts: dict[str, int] = {
+        "sections_total": len(scan.sections),
+        "directory_entries": len(scan.directory_entries),
+    }
+    for section in scan.sections:
+        key = f"{section.kind_guess}_sections"
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _builder_family_counts(state: LegacyNativeState) -> dict[str, int]:
+    return {
+        "generic_families": len(state.generic_families),
+        "arrow_families": 1 if state.has_arrow_family else 0,
+        "sound_resources": 1 if state.has_sound_resource else 0,
+        "model_outputs": len(state.expected_model_files),
+        "animation_outputs": len(state.expected_animation_files),
+        "texture_outputs": len(state.expected_texture_files),
+        "sound_outputs": len(state.expected_sound_files),
+    }
+
+
+def _read_legacy_sections_summary(out_dir: Path) -> dict[str, int]:
+    manifest_path = out_dir / "legacy_sections.json"
+    if not manifest_path.exists():
+        return {}
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    sections = manifest.get("sections")
+    if not isinstance(sections, list):
+        return {}
+    routed_outputs = 0
+    model_outputs = 0
+    typed_model_outputs = 0
+    typed_bone_hits = 0
+    segmented_model_outputs = 0
+    segmented_bone_hits = 0
+    child_allocated_model_outputs = 0
+    child_allocated_bone_hits = 0
+    head_child_allocated_model_outputs = 0
+    head_child_allocated_bone_hits = 0
+    detail_child_allocated_model_outputs = 0
+    detail_child_allocated_bone_hits = 0
+    for entry in sections:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("asset_guess", "")).endswith("_model"):
+            model_outputs += 1
+            if entry.get("model_source_section_ordinal") is not None:
+                routed_outputs += 1
+            hits = int(entry.get("model_typed_bone_hits", 0) or 0)
+            typed_bone_hits += hits
+            if hits > 0:
+                typed_model_outputs += 1
+            segmented_hits = int(entry.get("model_segmented_record_hits", 0) or 0)
+            segmented_bone_hits += segmented_hits
+            if segmented_hits > 0:
+                segmented_model_outputs += 1
+            child_hits = int(entry.get("model_child_allocated_bone_hits", 0) or 0)
+            child_allocated_bone_hits += child_hits
+            if child_hits > 0:
+                child_allocated_model_outputs += 1
+            head_child_hits = int(entry.get("model_head_child_allocations", 0) or 0)
+            head_child_allocated_bone_hits += head_child_hits
+            if head_child_hits > 0:
+                head_child_allocated_model_outputs += 1
+            detail_child_hits = (
+                int(entry.get("model_ear_child_allocations", 0) or 0)
+                + int(entry.get("model_foot_child_allocations", 0) or 0)
+                + int(entry.get("model_leg_child_allocations", 0) or 0)
+                + int(entry.get("model_tail_child_allocations", 0) or 0)
+                + int(entry.get("model_body_child_allocations", 0) or 0)
+            )
+            detail_child_allocated_bone_hits += detail_child_hits
+            if detail_child_hits > 0:
+                detail_child_allocated_model_outputs += 1
+    return {
+        "legacy_sections_model_outputs": model_outputs,
+        "legacy_sections_model_source_routed_outputs": routed_outputs,
+        "legacy_sections_typed_model_outputs": typed_model_outputs,
+        "legacy_sections_typed_model_bone_hits": typed_bone_hits,
+        "legacy_sections_segmented_model_outputs": segmented_model_outputs,
+        "legacy_sections_segmented_model_bone_hits": segmented_bone_hits,
+        "legacy_sections_child_allocated_model_outputs": child_allocated_model_outputs,
+        "legacy_sections_child_allocated_model_bone_hits": child_allocated_bone_hits,
+        "legacy_sections_head_child_allocated_model_outputs": head_child_allocated_model_outputs,
+        "legacy_sections_head_child_allocated_model_bone_hits": head_child_allocated_bone_hits,
+        "legacy_sections_detail_child_allocated_model_outputs": detail_child_allocated_model_outputs,
+        "legacy_sections_detail_child_allocated_model_bone_hits": detail_child_allocated_bone_hits,
+    }
+
+
+def export_legacy_native_lift(
+    path: Path,
+    out_dir: Path | None = None,
+    *,
+    debug: bool = False,
+    source_root: Path | None = None,
+    official_export_root: Path | None = None,
+) -> Path:
+    del debug
+    ysm_path = path.resolve()
+    state = parse_legacy_native_state(ysm_path)
+    out_dir = (out_dir or _default_out_dir(ysm_path, state.codec_format)).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    materialization_backend: str
+    chosen_source_root: Path | None = source_root.resolve() if source_root is not None else None
+    chosen_official_root: Path | None = official_export_root.resolve() if official_export_root is not None else None
+    source_match_count = 0
+    source_asset_count = len(state.assets)
+    used_source_oracle = False
+    semantic_stage = "schema_only"
+    record_family_counts: dict[str, int] = {}
+
+    if chosen_official_root is not None:
+        snapshot_official_export(chosen_official_root, out_dir=out_dir, ysm_path=ysm_path)
+        materialization_backend = "official_export_snapshot"
+        semantic_stage = "official_snapshot_baseline"
+    else:
+        if chosen_source_root is None:
+            if state.codec_format in (1, 9, 15):
+                scan = scan_legacy_sections(ysm_path)
+                with contextlib.redirect_stdout(io.StringIO()):
+                    dump_legacy_sections(ysm_path, scan=scan, debug=False, out_dir=out_dir)
+                materialization_backend = "legacy_sections_source_less"
+                semantic_stage = "source_less_partial"
+                record_family_counts = _record_family_counts(scan)
+                section_summary = _read_legacy_sections_summary(out_dir)
+                if section_summary:
+                    record_family_counts.update(section_summary)
+                    child_allocated_outputs = section_summary.get("legacy_sections_child_allocated_model_outputs", 0)
+                    head_child_allocated_outputs = section_summary.get("legacy_sections_head_child_allocated_model_outputs", 0)
+                    detail_child_allocated_outputs = section_summary.get("legacy_sections_detail_child_allocated_model_outputs", 0)
+                    segmented_outputs = section_summary.get("legacy_sections_segmented_model_outputs", 0)
+                    typed_outputs = section_summary.get("legacy_sections_typed_model_outputs", 0)
+                    routed_outputs = section_summary.get("legacy_sections_model_source_routed_outputs", 0)
+                    if detail_child_allocated_outputs > 0 and routed_outputs > 0:
+                        semantic_stage = "source_less_family_routed_typed_segmented_child_allocated_head_mask_detail_model_partial"
+                    elif detail_child_allocated_outputs > 0:
+                        semantic_stage = "source_less_typed_segmented_child_allocated_head_mask_detail_model_partial"
+                    elif head_child_allocated_outputs > 0 and routed_outputs > 0:
+                        semantic_stage = "source_less_family_routed_typed_segmented_child_allocated_head_mask_model_partial"
+                    elif head_child_allocated_outputs > 0:
+                        semantic_stage = "source_less_typed_segmented_child_allocated_head_mask_model_partial"
+                    elif child_allocated_outputs > 0 and routed_outputs > 0:
+                        semantic_stage = "source_less_family_routed_typed_segmented_child_allocated_model_partial"
+                    elif child_allocated_outputs > 0:
+                        semantic_stage = "source_less_typed_segmented_child_allocated_model_partial"
+                    elif segmented_outputs > 0 and routed_outputs > 0:
+                        semantic_stage = "source_less_family_routed_typed_segmented_model_partial"
+                    elif segmented_outputs > 0:
+                        semantic_stage = "source_less_typed_segmented_model_partial"
+                    elif typed_outputs > 0 and routed_outputs > 0:
+                        semantic_stage = "source_less_family_routed_typed_model_partial"
+                    elif typed_outputs > 0:
+                        semantic_stage = "source_less_typed_model_partial"
+                    elif routed_outputs > 0:
+                        semantic_stage = "source_less_family_routed_partial"
+            else:
+                best_source, source_match_count, source_asset_count = find_best_source_oracle(ysm_path)
+                if best_source is not None:
+                    chosen_source_root = best_source.resolve()
+        if chosen_source_root is not None:
+            summary = restore_from_source_oracle(
+                ysm_path,
+                chosen_source_root,
+                out_dir=out_dir,
+                clean=True,
+                prefer_source_filenames=False,
+            )
+            source_match_count = summary.match_count
+            source_asset_count = summary.asset_count
+            if source_match_count == 0:
+                raise RuntimeError(f"source oracle {chosen_source_root} did not match any property-hash assets for {ysm_path.name}")
+            materialization_backend = "source_oracle_exact_restore"
+            used_source_oracle = True
+            semantic_stage = "oracle_exact_materialization"
+        elif chosen_official_root is None and state.codec_format not in (1, 9, 15):
+            raise RuntimeError(
+                "native lift export still needs --official-export-root or --source-root for this format; "
+                "source-less semantic export is only prepared for legacy 1/9/15 at the moment"
+            )
+
+    sanity_issues = _run_sanity_checks(state, out_dir)
+    _write_state_files(
+        out_dir,
+        state,
+        materialization_backend=materialization_backend,
+        used_source_oracle=used_source_oracle,
+        semantic_stage=semantic_stage,
+        record_family_counts=record_family_counts,
+        builder_family_counts=_builder_family_counts(state),
+        source_root=chosen_source_root,
+        official_export_root=chosen_official_root,
+        source_match_count=source_match_count,
+        source_asset_count=source_asset_count,
+        sanity_issues=sanity_issues,
+    )
+    return out_dir
+
+
+def dump_legacy_native_schema(path: Path, out_dir: Path | None = None) -> Path:
+    ysm_path = path.resolve()
+    state = parse_legacy_native_state(ysm_path)
+    out_dir = (out_dir or _default_out_dir(ysm_path, state.codec_format)).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    _write_state_files(out_dir, state)
+    return out_dir
+
+
+def _print_state_summary(state: LegacyNativeState) -> None:
+    print(f"file: {state.path}")
+    print(f"property_name: {state.property_name}")
+    print(f"codec_format: {state.codec_format}")
+    print(f"decoded_len: {state.decoded_len}")
+    print(f"generic_families: {', '.join(state.generic_families)}")
+    print(f"has_arrow_family: {str(state.has_arrow_family).lower()}")
+    print(f"has_sound_resource: {str(state.has_sound_resource).lower()}")
+    print(f"expected_model_files: {', '.join(state.expected_model_files)}")
+    print(f"expected_animation_files: {', '.join(state.expected_animation_files)}")
+    print(f"expected_texture_files: {', '.join(state.expected_texture_files)}")
+    print(f"expected_sound_files: {', '.join(state.expected_sound_files)}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Schema-first Python lift for YSM legacy export research. This path is strict: it models the recovered native families and only materializes exact outputs when an oracle baseline is available."
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    export = sub.add_parser("export", help="materialize a legacy export folder through the strict native-lift lane")
+    export.add_argument("ysm_path", type=Path)
+    export.add_argument("--out-dir", type=Path)
+    export.add_argument("--source-root", type=Path, help="optional source-oracle tree for exact restore materialization")
+    export.add_argument("--official-export-root", type=Path, help="optional real YSM export root or snapshot to normalize")
+    export.add_argument("--debug", action="store_true", help="reserved for future semantic record dumps")
+
+    dump = sub.add_parser("dump-schema", help="dump the recovered native state model without materializing assets")
+    dump.add_argument("ysm_path", type=Path)
+    dump.add_argument("--out-dir", type=Path)
+
+    args = ap.parse_args()
+    if args.cmd == "dump-schema":
+        out_dir = dump_legacy_native_schema(args.ysm_path, out_dir=args.out_dir)
+        state = parse_legacy_native_state(args.ysm_path.resolve())
+        _print_state_summary(state)
+        print(f"schema_dump: {out_dir}")
+        return 0
+
+    out_dir = export_legacy_native_lift(
+        args.ysm_path,
+        out_dir=args.out_dir,
+        debug=args.debug,
+        source_root=args.source_root,
+        official_export_root=args.official_export_root,
+    )
+    manifest = json.loads((out_dir / "native_lift_manifest.json").read_text(encoding="utf-8"))
+    state = parse_legacy_native_state(args.ysm_path.resolve())
+    _print_state_summary(state)
+    print(f"materialization_backend: {manifest['materialization_backend']}")
+    print(f"used_source_oracle: {str(bool(manifest['used_source_oracle'])).lower()}")
+    print(f"semantic_stage: {manifest['semantic_stage']}")
+    if manifest["source_root"] is not None:
+        print(f"source_root: {manifest['source_root']}")
+        print(f"source_match: {manifest['source_match_count']}/{manifest['source_asset_count']}")
+    if manifest["official_export_root"] is not None:
+        print(f"official_export_root: {manifest['official_export_root']}")
+    print(f"sanity_issue_count: {manifest['sanity_issue_count']}")
+    print(f"error_level_sanity_count: {manifest['error_level_sanity_count']}")
+    print(f"warning_level_sanity_count: {manifest['warning_level_sanity_count']}")
+    print(f"dump_folder: {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/v3_wrapper_transcode.py
+++ b/tools/ysm_extractor/v3_wrapper_transcode.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+ZSTD_FRAME_MAGIC = 0xFD2FB528
+ZSTD_SKIPPABLE_MASK = 0xFFFFFFF0
+ZSTD_SKIPPABLE_MAGIC = 0x184D2A50
+WRAPPER_BLOCK_XOR = 0x00D4E9
+
+
+@dataclass(frozen=True)
+class WrapperBlock:
+    last: bool
+    wrapper_type: int
+    stock_type: int
+    block_size: int
+    payload_size: int
+    header_offset: int
+    payload_offset: int
+    next_offset: int
+
+
+def zstd_frame_header_size(buf: bytes, off: int = 0) -> int:
+    if off < 0 or off + 6 > len(buf):
+        return -1
+    if int.from_bytes(buf[off:off + 4], "little") != ZSTD_FRAME_MAGIC:
+        return -1
+    desc = buf[off + 4]
+    single_segment = (desc >> 5) & 1
+    dict_id_flag = desc & 0x3
+    fcs_flag = desc >> 6
+
+    size = 5
+    if not single_segment:
+        size += 1
+    size += (0, 1, 2, 4)[dict_id_flag]
+    if fcs_flag == 0:
+        if single_segment:
+            size += 1
+    elif fcs_flag == 1:
+        size += 2
+    elif fcs_flag == 2:
+        size += 4
+    else:
+        size += 8
+    return size if off + size <= len(buf) else -1
+
+
+def zstd_frame_checksum_flag(buf: bytes, off: int = 0) -> bool:
+    if off < 0 or off + 5 > len(buf):
+        return False
+    if int.from_bytes(buf[off:off + 4], "little") != ZSTD_FRAME_MAGIC:
+        return False
+    desc = buf[off + 4]
+    return ((desc >> 2) & 1) != 0
+
+
+def parse_wrapper_block(buf: bytes, off: int) -> WrapperBlock:
+    if off < 0 or off + 3 > len(buf):
+        raise ValueError("short wrapper block header")
+    b0 = buf[off]
+    b1 = buf[off + 1]
+    b2 = buf[off + 2]
+    wrapper_type = (b0 >> 5) & 0x3
+    if wrapper_type == 2:
+        raise ValueError("wrapper block type 2 is reserved/error")
+    block_size = ((((b0 & 0x1F) << 16) | (b2 << 8) | b1) ^ WRAPPER_BLOCK_XOR)
+    if block_size < 0:
+        raise ValueError("negative wrapper payload size")
+    last = (b0 & 0x80) != 0
+    stock_type = {0: 2, 1: 1, 3: 0}[wrapper_type]
+    payload_size = 1 if wrapper_type == 1 else block_size
+    payload_off = off + 3
+    next_off = payload_off + payload_size
+    if next_off > len(buf):
+        raise ValueError("wrapper block overruns input")
+    return WrapperBlock(
+        last=last,
+        wrapper_type=wrapper_type,
+        stock_type=stock_type,
+        block_size=block_size,
+        payload_size=payload_size,
+        header_offset=off,
+        payload_offset=payload_off,
+        next_offset=next_off,
+    )
+
+
+def build_stock_block_header(last: bool, stock_type: int, payload_size: int) -> bytes:
+    if stock_type < 0 or stock_type > 2:
+        raise ValueError("unsupported stock block type")
+    if payload_size < 0 or payload_size > 0x1FFFFF:
+        raise ValueError("unsupported stock payload size")
+    hdr = (1 if last else 0) | (stock_type << 1) | (payload_size << 3)
+    return hdr.to_bytes(4, "little")[:3]
+
+
+def transcode_wrapper_stream_to_zstd(buf: bytes) -> bytes:
+    """
+    Evidence-backed transcode path:
+    - preserve stock-looking frame header and skippable frames
+    - rewrite each custom 3-byte wrapper block header into a stock Zstd block header
+    - preserve block payload bytes as-is
+
+    Wrapper type handling proven by the shared decompressor:
+    - type 0: compressed, payload bytes == block size
+    - type 1: RLE, payload bytes == 1, decoded size == block size
+    - type 3: raw, payload bytes == block size
+    """
+    out = bytearray()
+    off = 0
+    end = len(buf)
+    while off < end:
+        if off + 4 > end:
+            raise ValueError("truncated wrapper/frame lead")
+        magic = int.from_bytes(buf[off:off + 4], "little")
+        if magic == ZSTD_FRAME_MAGIC:
+            hdr_size = zstd_frame_header_size(buf, off)
+            if hdr_size < 0:
+                raise ValueError("invalid zstd frame header")
+            has_checksum = zstd_frame_checksum_flag(buf, off)
+            out.extend(buf[off:off + hdr_size])
+            off += hdr_size
+            while True:
+                blk = parse_wrapper_block(buf, off)
+                out.extend(build_stock_block_header(blk.last, blk.stock_type, blk.block_size))
+                out.extend(buf[blk.payload_offset:blk.next_offset])
+                off = blk.next_offset
+                if blk.last:
+                    if has_checksum:
+                        if off + 4 > end:
+                            raise ValueError("truncated frame checksum")
+                        out.extend(buf[off:off + 4])
+                        off += 4
+                    break
+            continue
+        if (magic & ZSTD_SKIPPABLE_MASK) == ZSTD_SKIPPABLE_MAGIC:
+            if off + 8 > end:
+                raise ValueError("truncated skippable frame")
+            size = int.from_bytes(buf[off + 4:off + 8], "little")
+            frame_end = off + 8 + size
+            if frame_end > end:
+                raise ValueError("skippable frame overruns input")
+            out.extend(buf[off:frame_end])
+            off = frame_end
+            continue
+        raise ValueError(f"unexpected wrapper/frame magic 0x{magic:08x} at 0x{off:x}")
+    return bytes(out)

--- a/tools/ysm_extractor/verify_format15_equivalence.py
+++ b/tools/ysm_extractor/verify_format15_equivalence.py
@@ -1,0 +1,9 @@
+from _extractor_bootstrap import ensure_local_extractors
+
+ensure_local_extractors(__file__)
+
+from extractors.verify_format15_equivalence import *  # noqa: F401,F403
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/verify_format1_equivalence.py
+++ b/tools/ysm_extractor/verify_format1_equivalence.py
@@ -1,0 +1,9 @@
+from _extractor_bootstrap import ensure_local_extractors
+
+ensure_local_extractors(__file__)
+
+from extractors.verify_format1_equivalence import *  # noqa: F401,F403
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/verify_format9_equivalence.py
+++ b/tools/ysm_extractor/verify_format9_equivalence.py
@@ -1,0 +1,9 @@
+from _extractor_bootstrap import ensure_local_extractors
+
+ensure_local_extractors(__file__)
+
+from extractors.verify_format9_equivalence import *  # noqa: F401,F403
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/verify_legacy_pair.py
+++ b/tools/ysm_extractor/verify_legacy_pair.py
@@ -1,0 +1,9 @@
+from _extractor_bootstrap import ensure_local_extractors
+
+ensure_local_extractors(__file__)
+
+from extractors.verify_legacy_pair import *  # noqa: F401,F403
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/ysgp_outer_v3_static.py
+++ b/tools/ysm_extractor/ysgp_outer_v3_static.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from ysgp_container_scanner import detect_property_end
+
+
+MAGIC_PREFIX = b"\xef\xbb\xbfYSGP"
+MASK64 = 0xFFFFFFFFFFFFFFFF
+
+
+def _u8(data: bytes, off: int) -> int:
+    return data[off]
+
+
+def _u32_partial(data: bytes, off: int) -> int:
+    return int.from_bytes(data[off:off + 4], "little")
+
+
+def _u64(data: bytes, off: int) -> int:
+    return int.from_bytes(data[off:off + 8], "little")
+
+
+def _rol64(x: int, n: int) -> int:
+    x &= MASK64
+    return ((x << n) | (x >> (64 - n))) & MASK64
+
+
+def _mul64(a: int, b: int) -> int:
+    return (a * b) & MASK64
+
+
+def _bswap64(x: int) -> int:
+    return int.from_bytes((x & MASK64).to_bytes(8, "little"), "big")
+
+
+def hash64_with_key(data: bytes, key: int) -> int:
+    n = len(data)
+    if n < 0x21:
+        l3 = 0xAF29CE778879D9C7
+        if n < 0x11:
+            if n < 8:
+                if n < 4:
+                    if n != 0:
+                        u10 = (
+                            _mul64(((_u8(data, n - 1) << 2) | n), 0xE4986A230E5AAA17)
+                            ^ _mul64(((_u8(data, n >> 1) << 8) | _u8(data, 0)), 0xAF29CE778879D9C7)
+                        ) & MASK64
+                        l3 = _mul64((u10 >> 47) ^ u10, 0xAF29CE778879D9C7)
+                    final_l3 = l3
+                else:
+                    l3 = (n * 2 + 0xAF29CE778879D9C7) & MASK64
+                    u10 = (n + _u32_partial(data, 0) * 8) & MASK64
+                    u5 = _u32_partial(data, n - 4)
+                    u10 = _mul64(u10 ^ u5, l3)
+                    u10 = _mul64((u10 >> 47) ^ u5 ^ u10, l3)
+                    u10 ^= (u10 >> 47)
+                    final_l3 = _mul64(u10, l3)
+            else:
+                l3 = (n * 2 + 0xAF29CE778879D9C7) & MASK64
+                u4 = (_u64(data, 0) + 0xAF29CE778879D9C7) & MASK64
+                u5 = _u64(data, n - 8)
+                u10 = (_mul64(_rol64(u5, 27), l3) + u4) & MASK64
+                u5 = _mul64((_rol64(u4, 39) + u5) & MASK64, l3)
+                u10 = _mul64(u10 ^ u5, l3)
+                u10 = _mul64((u10 >> 47) ^ u5 ^ u10, l3)
+                u10 ^= (u10 >> 47)
+                final_l3 = _mul64(u10, l3)
+        else:
+            l3 = (n * 2 + 0xAF29CE778879D9C7) & MASK64
+            u5 = _mul64(_u64(data, n - 8), l3)
+            u10 = (_mul64(_u64(data, 0), 0x91AF10802CAB25A5) + _u64(data, 16)) & MASK64
+            u4 = (_u64(data, 16) + 0xAF29CE778879D9C7) & MASK64
+            u4 = (_rol64(u4, 46) + _mul64(_u64(data, 0), 0x91AF10802CAB25A5) + u5) & MASK64
+            u10 = _mul64(
+                (
+                    _rol64(u5, 34)
+                    + _rol64(u10, 21)
+                    + _mul64(_u64(data, n - 16), 0xAF29CE778879D9C7)
+                    ^ u4
+                ) & MASK64,
+                l3,
+            )
+            u10 = _mul64((u10 >> 47) ^ u4 ^ u10, l3)
+            u10 ^= (u10 >> 47)
+            final_l3 = _mul64(u10, l3)
+    elif n < 0x41:
+        l1 = (n * 2 + 0xAF29CE778879D9C7) & MASK64
+        u10 = _u64(data, n - 0x20)
+        l2 = _u64(data, n - 0x18)
+        u5 = _u64(data, 16)
+        l8 = (_u64(data, 24) * 9) & MASK64
+        l15 = _u64(data, n - 8)
+        l11 = _mul64(_u64(data, n - 0x10), l1)
+        u7 = (_mul64(_u64(data, 0), 0xAF29CE778879D9C7) + l15) & MASK64
+        u16 = u7 ^ u10
+        u4 = (_mul64(_u64(data, 32), 0xAF29CE778879D9C7) + l8) & MASK64
+        u7 = _mul64((((_rol64(u5, 34) + l2) * 9) + _rol64(u7, 43) + u16 + l8 + 1) & MASK64, l1)
+        l3 = (_rol64(u4, 22) + l2) & MASK64
+        u7 = _mul64((l8 + u16 + l11 + 1 + _bswap64(u7)) & MASK64, l1)
+        u7 = _mul64((l15 + u4 + l2 + l3 + _bswap64(u7)) & MASK64, l1)
+        u10 = (l11 + u10 + _mul64((u4 + l2 + u5 + _bswap64(u7)) & MASK64, l1)) & MASK64
+        final_l3 = (_mul64((u10 >> 47) ^ u10, l1) + l3) & MASK64
+    else:
+        l3 = _u64(data, n - 0x28)
+        l1 = _u64(data, n - 0x10)
+        l2 = _u64(data, n - 0x38)
+        l15 = _u64(data, n - 0x30)
+        u10 = (l2 + l1) & MASK64
+        u5 = (l15 + n) & MASK64
+        u4 = _u64(data, n - 0x18)
+        u7 = _mul64(u4 ^ u5, 0xDE0F6EE09BDBAB91)
+        u5 = _mul64((u7 >> 47) ^ u5 ^ u7, 0xDE0F6EE09BDBAB91)
+        u5 = _mul64((u5 >> 47) ^ u5, 0xDE0F6EE09BDBAB91)
+        l8 = (_u64(data, n - 0x40) + n) & MASK64
+        u14 = (l3 + l8 + u5) & MASK64
+        u7 = (l2 + l15 + l8) & MASK64
+        u16 = (u7 + l3) & MASK64
+        u14 = (_rol64(u7, 20) + l8 + _rol64(u14, 43)) & MASK64
+        l2 = _u64(data, n - 8)
+        l15 = (_u64(data, n - 0x20) + u10 + 0x91AF10802CAB25A5) & MASK64
+        u13 = (l3 + l2 + l15) & MASK64
+        u4 = (u4 + l1 + l15) & MASK64
+        u7 = (u4 + l2) & MASK64
+        l3 = (_mul64(l3, 0x91AF10802CAB25A5) + _u64(data, 0)) & MASK64
+        u4 = (_rol64(u4, 20) + l15 + _rol64(u13, 43)) & MASK64
+        u13 = 0
+        while (((n - 1) & 0xFFFFFFFFFFFFFFC0) != u13):
+            l1 = _u64(data, u13 + 8)
+            l2 = _u64(data, u13 + 0x10)
+            u6 = (l3 + u16 + u10 + l1) & MASK64
+            l15 = _u64(data, u13 + 0x30)
+            u10 = (u10 + u14 + l15) & MASK64
+            u6 = _mul64(_rol64(u6, 27), 0x91AF10802CAB25A5) ^ u4
+            l8 = _u64(data, u13 + 0x28)
+            u10 = (u16 + l8 + _mul64(_rol64(u10, 22), 0x91AF10802CAB25A5)) & MASK64
+            l3 = _mul64(_rol64((u5 + u7) & MASK64, 31), 0x91AF10802CAB25A5)
+            l11 = _u64(data, u13 + 0x18)
+            l12 = (_mul64(u14, 0x91AF10802CAB25A5) + _u64(data, u13)) & MASK64
+            u14 = (l1 + l2 + l12) & MASK64
+            u16 = (u14 + l11) & MASK64
+            l9 = (u4 + l3 + _u64(data, u13 + 0x20)) & MASK64
+            l1 = _u64(data, u13 + 0x38)
+            u4 = (l2 + u10 + l9 + l1) & MASK64
+            u5 = (u7 + l12 + l11 + u6) & MASK64
+            u14 = (l12 + _rol64(u14, 20) + _rol64(u5, 43)) & MASK64
+            u5 = (l8 + l15 + l9) & MASK64
+            u7 = (u5 + l1) & MASK64
+            u4 = (l9 + _rol64(u5, 20) + _rol64(u4, 43)) & MASK64
+            u13 += 0x40
+            u5 = u6
+        u5 = _mul64(u7 ^ u16, 0xDE0F6EE09BDBAB91)
+        u5 = _mul64((u5 >> 47) ^ u16 ^ u5, 0xDE0F6EE09BDBAB91)
+        u10 = (
+            _mul64((u10 >> 47) ^ u10, 0x91AF10802CAB25A5)
+            + u6
+            + _mul64((u5 >> 47) ^ u5, 0xDE0F6EE09BDBAB91)
+        ) & MASK64
+        u5 = _mul64(u4 ^ u14, 0xDE0F6EE09BDBAB91)
+        u5 = _mul64((u5 >> 47) ^ u14 ^ u5, 0xDE0F6EE09BDBAB91)
+        u5 = _mul64((_mul64((u5 >> 47) ^ u5, 0xDE0F6EE09BDBAB91) + l3 ^ u10) & MASK64, 0xDE0F6EE09BDBAB91)
+        u10 = _mul64((u5 >> 47) ^ u10 ^ u5, 0xDE0F6EE09BDBAB91)
+        final_l3 = _mul64((u10 >> 47) ^ u10, 0xDE0F6EE09BDBAB91)
+
+    u10 = _mul64((key ^ ((final_l3 + 0x50D6318877862639) & MASK64)) & MASK64, 0xDE0F6EE09BDBAB91)
+    u10 = _mul64((u10 >> 47) ^ ((final_l3 + 0x50D6318877862639) & MASK64) ^ u10, 0xDE0F6EE09BDBAB91)
+    return _mul64((u10 >> 47) ^ u10, 0xDE0F6EE09BDBAB91)
+
+
+@dataclass(frozen=True)
+class OuterV3Layout:
+    path: Path
+    property_end: int
+    separator_offset: int
+    version_offset: int
+    version_value: int
+    encoded_plus_key_and_trailer_offset: int
+    trailing_hash_offset: int
+    trailing_hash_le: int
+    encoded_plus_key_len: int
+    trailer_hash_verified: bool
+
+
+def u32le(data: bytes, off: int) -> int:
+    return int.from_bytes(data[off:off + 4], "little")
+
+
+def u64le(data: bytes, off: int) -> int:
+    return int.from_bytes(data[off:off + 8], "little")
+
+
+def derive_selectors_from_hash(h: int) -> tuple[int, int]:
+    sel_a = (h & 0x3F) | 0x40
+    sel_b = 10 + 10 * (h % 3)
+    return sel_a, sel_b
+
+
+def parse_outer_v3_layout(path: Path) -> OuterV3Layout:
+    data = path.read_bytes()
+    if not data.startswith(MAGIC_PREFIX):
+        raise ValueError("file does not start with UTF-8 BOM + YSGP")
+
+    property_end = detect_property_end(data)
+    if property_end + 5 + 8 > len(data):
+        raise ValueError("file too short for proven outer v3 framing")
+
+    separator_offset = property_end
+    version_offset = property_end + 1
+    version_value = u32le(data, version_offset)
+    trailing_hash_offset = len(data) - 8
+    trailing_hash_le = u64le(data, trailing_hash_offset)
+    expected_trailer = hash64_with_key(data[:trailing_hash_offset], 0x9E5599DB80C67C29)
+
+    if data[separator_offset] != 0:
+        raise ValueError("expected 0x00 separator byte after property block")
+    if version_value != 3:
+        raise ValueError(f"expected outer version dword 3, got {version_value}")
+
+    return OuterV3Layout(
+        path=path,
+        property_end=property_end,
+        separator_offset=separator_offset,
+        version_offset=version_offset,
+        version_value=version_value,
+        encoded_plus_key_and_trailer_offset=property_end + 5,
+        trailing_hash_offset=trailing_hash_offset,
+        trailing_hash_le=trailing_hash_le,
+        encoded_plus_key_len=trailing_hash_offset - (property_end + 5),
+        trailer_hash_verified=trailing_hash_le == expected_trailer,
+    )
+
+
+def print_layout(layout: OuterV3Layout) -> None:
+    print(f"file: {layout.path}")
+    print(f"property_end: 0x{layout.property_end:08x}")
+    print(f"separator_offset: 0x{layout.separator_offset:08x}")
+    print(f"version_offset: 0x{layout.version_offset:08x}")
+    print(f"version_value: {layout.version_value}")
+    print(
+        "encoded_plus_key_offset: "
+        f"0x{layout.encoded_plus_key_and_trailer_offset:08x}"
+    )
+    print(f"trailing_hash_offset: 0x{layout.trailing_hash_offset:08x}")
+    print(f"trailing_hash_le: 0x{layout.trailing_hash_le:016x}")
+    print(f"trailer_hash_verified: {layout.trailer_hash_verified}")
+    print(f"encoded_plus_key_len: 0x{layout.encoded_plus_key_len:x}")
+    print("note: encoded-section bytes and raw key-material are not yet split here")
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Static-only outer v3 YSGP layout parser for headered .ysm files."
+    )
+    parser.add_argument("inputs", nargs="+")
+    parser.add_argument(
+        "--derive-selectors",
+        type=lambda x: int(x, 0),
+        help="Given a recovered hash64 value, print the proven selector bytes",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_argparser()
+    args = parser.parse_args()
+
+    if args.derive_selectors is not None:
+        sel_a, sel_b = derive_selectors_from_hash(args.derive_selectors)
+        print(f"hash=0x{args.derive_selectors:016x}")
+        print(f"sel_a=0x{sel_a:02x}")
+        print(f"sel_b={sel_b}")
+
+    for idx, input_path in enumerate(args.inputs):
+        if idx:
+            print()
+        print_layout(parse_outer_v3_layout(Path(input_path)))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/ysgp_v3_exact_probe.py
+++ b/tools/ysm_extractor/ysgp_v3_exact_probe.py
@@ -1,0 +1,842 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+from mt19937_64_reference import MT19937_64
+from provider1_chacha_reference import Provider1State, chacha_xor_stream, make_state_hchacha
+from v3_wrapper_transcode import transcode_wrapper_stream_to_zstd
+from v3_seed_mix_reference import SECOND_STAGE_SEED_KEY, derive_selectors_exact, mix56_exact
+from ysgp_end_to_end_extractor import (
+    CandidateProfile,
+    PROFILES,
+    OUTER_KEY_HASH_KEY,
+    _u64le,
+    decrypt_candidate,
+)
+from ysgp_outer_v3_static import hash64_with_key, parse_outer_v3_layout
+
+
+@dataclass(frozen=True)
+class V3ExactInput:
+    path: Path
+    ciphertext: bytes
+    key56: bytes
+    outer_hash: int
+    property_end: int
+    encoded_offset: int
+    key56_offset: int
+    outer_hash_offset: int
+    key_hash: int
+    sel_a: int
+    sel_b: int
+
+
+@dataclass
+class V3ExactCandidate:
+    score: int
+    rounds: int
+    profile: CandidateProfile
+    second_stage: str
+    prelude_skip: int
+    section_offset: int
+    section_tag: int
+    small_dword_count: int
+    ascii_head_ratio: float
+    zstd_header_ok: bool
+    zstd_block_type: int
+    zstd_block_size: int
+    wrapper_block_ok: bool
+    wrapper_block_type: int
+    wrapper_block_size: int
+    wrapper_transcode_ok: bool
+    wrapper_transcode_zstd_ok: bool
+    zstd_decompress_ok: bool
+    plaintext: bytes
+
+
+ZSTD_FRAME_MAGIC = 0xFD2FB528
+
+
+@dataclass
+class _RawSource:
+    data: bytes
+    pos: int = 0
+
+    def read(self, max_len: int) -> bytes:
+        if max_len <= 0 or self.pos >= len(self.data):
+            return b""
+        end = min(len(self.data), self.pos + max_len)
+        chunk = self.data[self.pos:end]
+        self.pos = end
+        return chunk
+
+
+@dataclass
+class _V3Stage1Reader:
+    lower: _RawSource
+    state48: bytearray
+    rounds: int
+    next_refill_len: int
+    postprocess_hash_key: int = OUTER_KEY_HASH_KEY
+    side_shift_mode: str = "right"
+    pending_len: int = 0
+    pending_block: bytearray = field(default_factory=lambda: bytearray(64))
+    side48: bytearray = field(default_factory=lambda: bytearray(48))
+
+    @classmethod
+    def from_input(
+        cls,
+        inp: V3ExactInput,
+        *,
+        postprocess_hash_key: int = OUTER_KEY_HASH_KEY,
+        side_shift_mode: str = "right",
+    ) -> "_V3Stage1Reader":
+        state = make_state_hchacha(
+            key32=inp.key56[:32],
+            secondary16=inp.key56[32:48],
+            secondary_qword64=_u64le(inp.key56, 48),
+            rounds=inp.sel_b,
+        )
+        state48 = bytearray()
+        state48.extend(state.key_or_subkey32)
+        state48.extend(state.counter64.to_bytes(8, "little"))
+        state48.extend(state.secondary_qword64.to_bytes(8, "little"))
+        return cls(
+            lower=_RawSource(inp.ciphertext),
+            state48=state48,
+            rounds=inp.sel_b,
+            next_refill_len=inp.sel_a << 6,
+            postprocess_hash_key=postprocess_hash_key,
+            side_shift_mode=side_shift_mode,
+        )
+
+    def _provider_state(self) -> Provider1State:
+        return Provider1State(
+            key_or_subkey32=bytes(self.state48[:32]),
+            counter64=_u64le(self.state48, 32),
+            secondary_qword64=_u64le(self.state48, 40),
+            rounds=self.rounds,
+        )
+
+    def _store_counter(self, state: Provider1State) -> None:
+        self.state48[32:40] = state.counter64.to_bytes(8, "little")
+
+    def _shift_side_state_right(self) -> None:
+        old = bytes(self.side48)
+        for i in range(48):
+            self.side48[i] = ((old[i] >> 1) & 0x7F) | ((old[(i - 1) % 48] & 1) << 7)
+
+    def _shift_side_state_left(self) -> None:
+        old = bytes(self.side48)
+        for i in range(48):
+            self.side48[i] = ((old[i] << 1) & 0xFE) | ((old[(i + 1) % 48] >> 7) & 1)
+
+    def _post_process_plain_chunk(self, plain_chunk: bytes) -> None:
+        chunk_hash = hash64_with_key(plain_chunk, self.postprocess_hash_key)
+        self.next_refill_len = (((chunk_hash & 0x3F) | 0x40) << 6)
+        self.rounds = 10 + 10 * (chunk_hash % 3)
+        if self.side_shift_mode == "right":
+            self._shift_side_state_right()
+        elif self.side_shift_mode == "left":
+            self._shift_side_state_left()
+        elif self.side_shift_mode != "none":
+            raise ValueError(f"unsupported side_shift_mode {self.side_shift_mode}")
+        _rolling_state_xor_update(self.state48, chunk_hash)
+
+    def _transform_chunk(self, src: bytes, finalize: bool) -> bytes:
+        state = self._provider_state()
+        out = bytearray()
+        off = 0
+
+        if self.pending_len + len(src) >= 0x40:
+            if self.pending_len != 0:
+                need = 0x40 - self.pending_len
+                self.pending_block[self.pending_len:self.pending_len + need] = src[:need]
+                out.extend(chacha_xor_stream(state, bytes(self.pending_block[:0x40])))
+                self.pending_len = 0
+                off += need
+
+            full = (len(src) - off) & ~0x3F
+            if full != 0:
+                out.extend(chacha_xor_stream(state, src[off:off + full]))
+                off += full
+
+        tail = src[off:]
+        if tail:
+            if finalize:
+                self.pending_block[self.pending_len:self.pending_len + len(tail)] = tail
+                self.pending_len += len(tail)
+                out.extend(chacha_xor_stream(state, bytes(self.pending_block[:self.pending_len])))
+                self.pending_len = 0
+            else:
+                self.pending_block[self.pending_len:self.pending_len + len(tail)] = tail
+                self.pending_len += len(tail)
+        elif finalize and self.pending_len:
+            out.extend(chacha_xor_stream(state, bytes(self.pending_block[:self.pending_len])))
+            self.pending_len = 0
+
+        self._store_counter(state)
+        return bytes(out)
+
+    def read_all(self) -> bytes:
+        out = bytearray()
+        while True:
+            requested = self.next_refill_len
+            chunk = self.lower.read(requested)
+            if not chunk:
+                out.extend(self._transform_chunk(b"", finalize=True))
+                break
+
+            finalize = len(chunk) != requested
+            plain = self._transform_chunk(chunk, finalize=finalize)
+            out.extend(plain)
+            if plain and not finalize:
+                self._post_process_plain_chunk(plain)
+            if finalize:
+                break
+        return bytes(out)
+
+
+def _u32le(data: bytes, off: int) -> int:
+    return int.from_bytes(data[off:off + 4], "little")
+
+
+def _ascii_ratio(data: bytes) -> float:
+    if not data:
+        return 1.0
+    printable = sum(0x20 <= b < 0x7F or b in (0x09, 0x0A, 0x0D) for b in data)
+    return printable / len(data)
+
+
+def _parse_zstd_block_header(buf: bytes) -> tuple[bool, int, int]:
+    if len(buf) < 9:
+        return False, -1, -1
+    if _u32le(buf, 0) != ZSTD_FRAME_MAGIC:
+        return False, -1, -1
+
+    desc = buf[4]
+    single_segment = (desc >> 5) & 1
+    dict_id_flag = desc & 0x3
+    fcs_flag = desc >> 6
+
+    off = 5
+    if not single_segment:
+        off += 1
+    off += (0, 1, 2, 4)[dict_id_flag]
+    if fcs_flag == 0:
+        if single_segment:
+            off += 1
+    elif fcs_flag == 1:
+        off += 2
+    elif fcs_flag == 2:
+        off += 4
+    else:
+        off += 8
+
+    if len(buf) < off + 3:
+        return False, -1, -1
+
+    block_header = buf[off] | (buf[off + 1] << 8) | (buf[off + 2] << 16)
+    block_type = (block_header >> 1) & 0x3
+    block_size = block_header >> 3
+    return block_type != 3 and block_size <= 131072, block_type, block_size
+
+
+def _zstd_frame_header_size(buf: bytes) -> int:
+    if len(buf) < 6 or _u32le(buf, 0) != ZSTD_FRAME_MAGIC:
+        return -1
+    desc = buf[4]
+    single_segment = (desc >> 5) & 1
+    dict_id_flag = desc & 0x3
+    fcs_flag = desc >> 6
+
+    off = 5
+    if not single_segment:
+        off += 1
+    off += (0, 1, 2, 4)[dict_id_flag]
+    if fcs_flag == 0:
+        if single_segment:
+            off += 1
+    elif fcs_flag == 1:
+        off += 2
+    elif fcs_flag == 2:
+        off += 4
+    else:
+        off += 8
+    return off if off <= len(buf) else -1
+
+
+def _parse_ysm_wrapper_block_header(buf: bytes) -> tuple[bool, int, int]:
+    hdr = _zstd_frame_header_size(buf)
+    if hdr < 0 or len(buf) < hdr + 3:
+        return False, -1, -1
+    b0 = buf[hdr]
+    b1 = buf[hdr + 1]
+    b2 = buf[hdr + 2]
+    block_type = (b0 >> 5) & 0x3
+    block_size = ((b0 & 0x1F) << 16) | (b2 << 8) | b1
+    block_size ^= 0x00D4E9
+    ok = block_type != 2 and 0 <= block_size <= 131072
+    return ok, block_type, block_size
+
+
+def _try_zstd_decompress(buf: bytes) -> bool:
+    if len(buf) < 4 or _u32le(buf, 0) != ZSTD_FRAME_MAGIC:
+        return False
+    zstd = shutil.which("zstd")
+    if zstd is None:
+        return False
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(buf)
+        tmp_path = tmp.name
+    try:
+        proc = subprocess.run(
+            [zstd, "-d", "-q", "-c", tmp_path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return proc.returncode == 0
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+def _derive_selectors_from_hash_exact(h: int) -> tuple[int, int]:
+    sel_a = (h & 0x3F) | 0x40
+    sel_b = 10 + 10 * (h % 3)
+    return sel_a, sel_b
+
+
+def parse_v3_exact_input(path: Path) -> V3ExactInput:
+    layout = parse_outer_v3_layout(path)
+    if not layout.trailer_hash_verified:
+        raise ValueError("outer trailer hash does not verify")
+
+    data = path.read_bytes()
+    encoded_offset = layout.encoded_plus_key_and_trailer_offset
+    outer_hash_offset = layout.trailing_hash_offset
+    key56_offset = outer_hash_offset - 56
+    if key56_offset <= encoded_offset:
+        raise ValueError("file too short for proven v3 ciphertext + key56 + outer hash layout")
+
+    ciphertext = data[encoded_offset:key56_offset]
+    key56 = data[key56_offset:outer_hash_offset]
+    outer_hash = _u64le(data, outer_hash_offset)
+    key_hash, sel_a, sel_b = derive_selectors_exact(key56)
+
+    return V3ExactInput(
+        path=path,
+        ciphertext=ciphertext,
+        key56=key56,
+        outer_hash=outer_hash,
+        property_end=layout.property_end,
+        encoded_offset=encoded_offset,
+        key56_offset=key56_offset,
+        outer_hash_offset=outer_hash_offset,
+        key_hash=key_hash,
+        sel_a=sel_a,
+        sel_b=sel_b,
+    )
+
+
+def decrypt_v3_confirmed(inp: V3ExactInput) -> bytes:
+    state = make_state_hchacha(
+        key32=inp.key56[:32],
+        secondary16=inp.key56[32:48],
+        secondary_qword64=_u64le(inp.key56, 48),
+        rounds=inp.sel_b,
+    )
+    return chacha_xor_stream(state, inp.ciphertext)
+
+
+def _rolling_state_xor_update(state48: bytearray, chunk_hash: int) -> None:
+    hash8 = chunk_hash.to_bytes(8, "little")
+    for i in range(0x30):
+        state48[i] ^= hash8[i & 7]
+
+
+def decrypt_v3_chunk_rekey(inp: V3ExactInput) -> bytes:
+    """
+    Likely read-path reconstruction from FUN_005d78c0 + slot +0x20 call flow.
+
+    Evidence-backed behavior:
+    - initial chunk size is `sel_a << 6`
+    - full raw ciphertext chunks are transformed with the current ChaCha state
+    - after each full chunk with more data remaining, the raw chunk is hashed with
+      the generic keyed hash and the first 0x30 bytes of state are XOR-updated
+    - the next chunk size and round count derive from that chunk hash
+
+    Remaining uncertainty:
+    - the auxiliary 0x40..0x6f state bytes mutated by the same helper are not
+      consumed by the recovered provider core, so they are omitted here
+    """
+
+    initial = make_state_hchacha(
+        key32=inp.key56[:32],
+        secondary16=inp.key56[32:48],
+        secondary_qword64=_u64le(inp.key56, 48),
+        rounds=inp.sel_b,
+    )
+    state48 = bytearray()
+    state48.extend(initial.key_or_subkey32)
+    state48.extend(initial.counter64.to_bytes(8, "little"))
+    state48.extend(initial.secondary_qword64.to_bytes(8, "little"))
+
+    rounds = inp.sel_b
+    chunk_len = inp.sel_a << 6
+    out = bytearray()
+    off = 0
+    total = len(inp.ciphertext)
+
+    while off < total:
+        take = min(chunk_len, total - off)
+        chunk = inp.ciphertext[off:off + take]
+        state = Provider1State(
+            key_or_subkey32=bytes(state48[:32]),
+            counter64=_u64le(state48, 32),
+            secondary_qword64=_u64le(state48, 40),
+            rounds=rounds,
+        )
+        plain_chunk = chacha_xor_stream(state, chunk)
+        out.extend(plain_chunk)
+        state48[32:40] = state.counter64.to_bytes(8, "little")
+        off += take
+
+        if off < total and take == chunk_len:
+            chunk_hash = hash64_with_key(plain_chunk, OUTER_KEY_HASH_KEY)
+            _rolling_state_xor_update(state48, chunk_hash)
+            chunk_sel_a, chunk_sel_b = _derive_selectors_from_hash_exact(chunk_hash)
+            chunk_len = chunk_sel_a << 6
+            rounds = chunk_sel_b
+
+    return bytes(out)
+
+
+def decrypt_v3_reader_exact(inp: V3ExactInput) -> bytes:
+    """
+    Confirmed object-level reconstruction of the first-stage v3 reader:
+    - lower source is the raw ciphertext span
+    - requested refill length starts at sel_a << 6
+    - produced plaintext chunks drive slot +0x20 post-processing
+    - post-processing mutates the live 0x30-byte provider state in place
+    """
+    return _V3Stage1Reader.from_input(inp).read_all()
+
+
+def decrypt_v3_reader_vtbl_17690(inp: V3ExactInput) -> bytes:
+    """
+    Likely BOM v3 reader variant tied to PTR_FUN_00e17690.
+
+    Evidence:
+    - slot +0x20 is FUN_005199b0, not FUN_005631f0
+    - FUN_005199b0 hashes chunks with 0xd1c3d1d13a99752b
+    - it applies the opposite side-state bit shift
+    """
+    return _V3Stage1Reader.from_input(
+        inp,
+        postprocess_hash_key=0xD1C3D1D13A99752B,
+        side_shift_mode="left",
+    ).read_all()
+
+
+def _apply_second_stage_mt(key56: bytes, src: bytes) -> bytes:
+    seed = mix56_exact(key56, SECOND_STAGE_SEED_KEY)
+    return MT19937_64.from_seed(seed).xor_stream(src)
+
+
+def _apply_second_stage_variant(key56: bytes, src: bytes, variant: str) -> bytes:
+    if variant == "none":
+        return src
+
+    seed = mix56_exact(key56, SECOND_STAGE_SEED_KEY)
+    mt = MT19937_64.from_seed(seed)
+
+    if variant.startswith("mt19937_64_phase"):
+        phase = int(variant.removeprefix("mt19937_64_phase"))
+        return mt.xor_stream_phase(src, phase, "little")
+    if variant.startswith("mt19937_64_be_phase"):
+        phase = int(variant.removeprefix("mt19937_64_be_phase"))
+        return mt.xor_stream_phase(src, phase, "big")
+    if variant.startswith("mt19937_64_skip"):
+        skip = int(variant.removeprefix("mt19937_64_skip"))
+        for _ in range(skip):
+            mt.next_u64()
+        return mt.xor_stream(src)
+
+    if variant == "mt19937_64_xor":
+        return mt.xor_stream(src)
+    if variant == "mt19937_64_xor_be":
+        return mt.xor_stream_endian(src, "big")
+
+    raise ValueError(f"unknown second-stage variant {variant}")
+
+
+def _score_stream_plaintext(
+    pt: bytes,
+    derived_rounds: int,
+    rounds: int,
+    profile: CandidateProfile,
+    second_stage: str,
+) -> tuple[int, int, int, int, int, float, bool, int, int, bool, int, int, bool, bool, bool]:
+    if len(pt) < 6:
+        return (-10_000, 0, 0, 0, 0, 1.0, False, -1, -1, False, -1, -1, False, False, False)
+
+    prelude_skip = int.from_bytes(pt[:2], "little") & 0x3FF
+    section_offset = 2 + prelude_skip
+    if section_offset + 4 > len(pt):
+        return (-9_000, prelude_skip, section_offset, 0, 0, 1.0, False, -1, -1, False, -1, -1, False, False, False)
+
+    section_tag = _u32le(pt, section_offset)
+    dwords = [_u32le(pt, off) for off in range(0, min(len(pt), 32), 4)]
+    small_dword_count = sum(1 for v in dwords if v < 0x100)
+    ascii_head_ratio = _ascii_ratio(pt[:0x80])
+    zstd_header_ok, zstd_block_type, zstd_block_size = _parse_zstd_block_header(pt[section_offset:])
+    wrapper_block_ok, wrapper_block_type, wrapper_block_size = _parse_ysm_wrapper_block_header(
+        pt[section_offset:]
+    )
+    wrapper_transcode_ok = False
+    wrapper_transcode_zstd_ok = False
+    if wrapper_block_ok:
+        try:
+            transcoded = transcode_wrapper_stream_to_zstd(pt[section_offset:])
+            wrapper_transcode_ok = True
+            wrapper_transcode_zstd_ok = _try_zstd_decompress(transcoded)
+        except Exception:
+            wrapper_transcode_ok = False
+            wrapper_transcode_zstd_ok = False
+    zstd_decompress_ok = _try_zstd_decompress(pt[section_offset:]) if zstd_header_ok else False
+
+    score = 0
+    if prelude_skip <= 0x100:
+        score += 30
+    elif prelude_skip <= 0x200:
+        score += 10
+    else:
+        score -= 20
+
+    if section_tag == ZSTD_FRAME_MAGIC:
+        score += 1200
+    elif (section_tag & 0xFFFFFFF0) == 0x184D2A50:
+        score += 800
+    elif 1 <= section_tag <= 31:
+        score += 200
+    elif section_tag < 0x100:
+        score += 30
+    elif section_tag < 0x10000:
+        score += 10
+
+    if zstd_header_ok:
+        score += 200
+    if wrapper_block_ok:
+        score += 1000
+        if wrapper_block_size <= 65536:
+            score += 100
+    if wrapper_transcode_ok:
+        score += 400
+    if wrapper_transcode_zstd_ok:
+        score += 4000
+    if zstd_decompress_ok:
+        score += 5000
+    score += small_dword_count * 6
+    if rounds == derived_rounds:
+        score += 20
+    if profile.confidence == "confirmed":
+        score += 10
+    if second_stage == "mt19937_64_xor":
+        score += 40
+    if ascii_head_ratio > 0.6:
+        score -= 10
+    return (
+        score,
+        prelude_skip,
+        section_offset,
+        section_tag,
+        small_dword_count,
+        ascii_head_ratio,
+        zstd_header_ok,
+        zstd_block_type,
+        zstd_block_size,
+        zstd_decompress_ok,
+        wrapper_block_type,
+        wrapper_block_size,
+        wrapper_block_ok,
+        wrapper_transcode_ok,
+        wrapper_transcode_zstd_ok,
+    )
+
+
+def enumerate_v3_exact_candidates(inp: V3ExactInput, extra_rounds: list[int]) -> list[V3ExactCandidate]:
+    results: list[V3ExactCandidate] = []
+    round_set = {inp.sel_b}
+    round_set.update(r for r in extra_rounds if r > 0 and (r & 1) == 0)
+    second_stage_variants = (
+        "none",
+        "mt19937_64_xor",
+        "mt19937_64_xor_be",
+        "mt19937_64_skip1",
+        "mt19937_64_skip2",
+        "mt19937_64_skip4",
+    )
+    for rounds in sorted(round_set):
+        for profile in PROFILES:
+            try:
+                chacha_pt = decrypt_candidate(inp.ciphertext, inp.key56, rounds, profile)
+            except Exception:
+                continue
+
+            for second_stage in second_stage_variants:
+                pt = _apply_second_stage_variant(inp.key56, chacha_pt, second_stage)
+                (
+                    score,
+                    prelude_skip,
+                    section_offset,
+                    section_tag,
+                    small_count,
+                    ascii_ratio,
+                    zstd_header_ok,
+                    zstd_block_type,
+                    zstd_block_size,
+                    zstd_decompress_ok,
+                    wrapper_block_type,
+                    wrapper_block_size,
+                    wrapper_block_ok,
+                    wrapper_transcode_ok,
+                    wrapper_transcode_zstd_ok,
+                ) = _score_stream_plaintext(
+                    pt,
+                    derived_rounds=inp.sel_b,
+                    rounds=rounds,
+                    profile=profile,
+                    second_stage=second_stage,
+                )
+                results.append(
+                    V3ExactCandidate(
+                        score=score,
+                        rounds=rounds,
+                        profile=profile,
+                        second_stage=second_stage,
+                        prelude_skip=prelude_skip,
+                        section_offset=section_offset,
+                        section_tag=section_tag,
+                        small_dword_count=small_count,
+                        ascii_head_ratio=ascii_ratio,
+                        zstd_header_ok=zstd_header_ok,
+                        zstd_block_type=zstd_block_type,
+                        zstd_block_size=zstd_block_size,
+                        wrapper_block_ok=wrapper_block_ok,
+                        wrapper_block_type=wrapper_block_type,
+                        wrapper_block_size=wrapper_block_size,
+                        wrapper_transcode_ok=wrapper_transcode_ok,
+                        wrapper_transcode_zstd_ok=wrapper_transcode_zstd_ok,
+                        zstd_decompress_ok=zstd_decompress_ok,
+                        plaintext=pt,
+                    )
+                )
+    rolling_profile = CandidateProfile(
+        derivation_mode="rolling_chunk_hash_state_xor",
+        state_layout="hchacha_qword_tail",
+        counter0=0,
+        confidence="likely",
+    )
+    try:
+        chacha_pt = decrypt_v3_chunk_rekey(inp)
+    except Exception:
+        chacha_pt = b""
+    if chacha_pt:
+        for second_stage in second_stage_variants:
+            pt = _apply_second_stage_variant(inp.key56, chacha_pt, second_stage)
+            (
+                score,
+                prelude_skip,
+                section_offset,
+                section_tag,
+                small_count,
+                ascii_ratio,
+                zstd_header_ok,
+                zstd_block_type,
+                zstd_block_size,
+                zstd_decompress_ok,
+                wrapper_block_type,
+                wrapper_block_size,
+                wrapper_block_ok,
+                wrapper_transcode_ok,
+                wrapper_transcode_zstd_ok,
+            ) = _score_stream_plaintext(
+                pt,
+                derived_rounds=inp.sel_b,
+                rounds=inp.sel_b,
+                profile=rolling_profile,
+                second_stage=second_stage,
+            )
+            results.append(
+                V3ExactCandidate(
+                    score=score,
+                    rounds=inp.sel_b,
+                    profile=rolling_profile,
+                    second_stage=second_stage,
+                    prelude_skip=prelude_skip,
+                    section_offset=section_offset,
+                    section_tag=section_tag,
+                    small_dword_count=small_count,
+                    ascii_head_ratio=ascii_ratio,
+                    zstd_header_ok=zstd_header_ok,
+                    zstd_block_type=zstd_block_type,
+                    zstd_block_size=zstd_block_size,
+                    wrapper_block_ok=wrapper_block_ok,
+                    wrapper_block_type=wrapper_block_type,
+                    wrapper_block_size=wrapper_block_size,
+                    wrapper_transcode_ok=wrapper_transcode_ok,
+                    wrapper_transcode_zstd_ok=wrapper_transcode_zstd_ok,
+                    zstd_decompress_ok=zstd_decompress_ok,
+                    plaintext=pt,
+                )
+            )
+    exact_reader_profile = CandidateProfile(
+        derivation_mode="exact_reader_live_workspace_post_005631f0",
+        state_layout="hchacha_qword_tail",
+        counter0=0,
+        confidence="confirmed",
+    )
+    try:
+        chacha_pt = decrypt_v3_reader_exact(inp)
+    except Exception:
+        chacha_pt = b""
+    if chacha_pt:
+        for second_stage in second_stage_variants:
+            pt = _apply_second_stage_variant(inp.key56, chacha_pt, second_stage)
+            (
+                score,
+                prelude_skip,
+                section_offset,
+                section_tag,
+                small_count,
+                ascii_ratio,
+                zstd_header_ok,
+                zstd_block_type,
+                zstd_block_size,
+                zstd_decompress_ok,
+                wrapper_block_type,
+                wrapper_block_size,
+                wrapper_block_ok,
+                wrapper_transcode_ok,
+                wrapper_transcode_zstd_ok,
+            ) = _score_stream_plaintext(
+                pt,
+                derived_rounds=inp.sel_b,
+                rounds=inp.sel_b,
+                profile=exact_reader_profile,
+                second_stage=second_stage,
+            )
+            results.append(
+                V3ExactCandidate(
+                    score=score,
+                    rounds=inp.sel_b,
+                    profile=exact_reader_profile,
+                    second_stage=second_stage,
+                    prelude_skip=prelude_skip,
+                    section_offset=section_offset,
+                    section_tag=section_tag,
+                    small_dword_count=small_count,
+                    ascii_head_ratio=ascii_ratio,
+                    zstd_header_ok=zstd_header_ok,
+                    zstd_block_type=zstd_block_type,
+                    zstd_block_size=zstd_block_size,
+                    wrapper_block_ok=wrapper_block_ok,
+                    wrapper_block_type=wrapper_block_type,
+                    wrapper_block_size=wrapper_block_size,
+                    wrapper_transcode_ok=wrapper_transcode_ok,
+                    wrapper_transcode_zstd_ok=wrapper_transcode_zstd_ok,
+                    zstd_decompress_ok=zstd_decompress_ok,
+                    plaintext=pt,
+                )
+            )
+    vtbl_17690_profile = CandidateProfile(
+        derivation_mode="reader_vtbl_17690_live_workspace_post_005199b0",
+        state_layout="hchacha_qword_tail",
+        counter0=0,
+        confidence="likely",
+    )
+    try:
+        chacha_pt = decrypt_v3_reader_vtbl_17690(inp)
+    except Exception:
+        chacha_pt = b""
+    if chacha_pt:
+        for second_stage in second_stage_variants:
+            pt = _apply_second_stage_variant(inp.key56, chacha_pt, second_stage)
+            (
+                score,
+                prelude_skip,
+                section_offset,
+                section_tag,
+                small_count,
+                ascii_ratio,
+                zstd_header_ok,
+                zstd_block_type,
+                zstd_block_size,
+                zstd_decompress_ok,
+                wrapper_block_type,
+                wrapper_block_size,
+                wrapper_block_ok,
+                wrapper_transcode_ok,
+                wrapper_transcode_zstd_ok,
+            ) = _score_stream_plaintext(
+                pt,
+                derived_rounds=inp.sel_b,
+                rounds=inp.sel_b,
+                profile=vtbl_17690_profile,
+                second_stage=second_stage,
+            )
+            results.append(
+                V3ExactCandidate(
+                    score=score,
+                    rounds=inp.sel_b,
+                    profile=vtbl_17690_profile,
+                    second_stage=second_stage,
+                    prelude_skip=prelude_skip,
+                    section_offset=section_offset,
+                    section_tag=section_tag,
+                    small_dword_count=small_count,
+                    ascii_head_ratio=ascii_ratio,
+                    zstd_header_ok=zstd_header_ok,
+                    zstd_block_type=zstd_block_type,
+                    zstd_block_size=zstd_block_size,
+                    wrapper_block_ok=wrapper_block_ok,
+                    wrapper_block_type=wrapper_block_type,
+                    wrapper_block_size=wrapper_block_size,
+                    wrapper_transcode_ok=wrapper_transcode_ok,
+                    wrapper_transcode_zstd_ok=wrapper_transcode_zstd_ok,
+                    zstd_decompress_ok=zstd_decompress_ok,
+                    plaintext=pt,
+                )
+            )
+    results.sort(key=lambda cand: cand.score, reverse=True)
+    return results
+
+
+def is_valid_v3_stream_candidate(cand: V3ExactCandidate) -> bool:
+    return (
+        cand.section_tag == ZSTD_FRAME_MAGIC
+        or (cand.section_tag & 0xFFFFFFF0) == 0x184D2A50
+        or cand.zstd_header_ok
+    )
+
+
+def dump_v3_candidate(base: Path, rank: int, cand: V3ExactCandidate) -> Path:
+    name = (
+        f"{base.stem}.v3stream_{rank:02d}"
+        f".score_{cand.score}"
+        f".skip_{cand.prelude_skip}"
+        f".off_{cand.section_offset}"
+        f".tag_{cand.section_tag}"
+        f".r{cand.rounds}"
+        f".{cand.profile.derivation_mode}"
+        f".{cand.profile.state_layout}"
+        f".{cand.second_stage}"
+        f".bin"
+    )
+    out_path = base.with_name(name)
+    out_path.write_bytes(cand.plaintext)
+    return out_path

--- a/tools/ysm_extractor/ysm_extract.py
+++ b/tools/ysm_extractor/ysm_extract.py
@@ -1,0 +1,9 @@
+from _extractor_bootstrap import ensure_local_extractors
+
+ensure_local_extractors(__file__)
+
+from extractors.ysm_extract import *  # noqa: F401,F403
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/ysm_extractor.py
+++ b/tools/ysm_extractor/ysm_extractor.py
@@ -1,0 +1,9 @@
+from _extractor_bootstrap import ensure_local_extractors
+
+ensure_local_extractors(__file__)
+
+from extractors.ysm_extract import *  # noqa: F401,F403
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ysm_extractor/ysm_legacy_native_lift.py
+++ b/tools/ysm_extractor/ysm_legacy_native_lift.py
@@ -1,0 +1,9 @@
+from _extractor_bootstrap import ensure_local_extractors
+
+ensure_local_extractors(__file__)
+
+from extractors.ysm_legacy_native_lift import *  # noqa: F401,F403
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Hey,

This project seem fun, I don't want it die so here what I'm gonna do

- Added `tools/ysm_extractor/` with the YSM Python CLI entrypoints and supporting extractor modules.
- Added `_extractor_bootstrap.py` so the CLI can locate `extractors/` correctly when run from this folder.
- Added root helper modules required by the extractor entrypoints (`ysgp_outer_v3_static.py`, `ysgp_v3_exact_probe.py`, `v3_wrapper_transcode.py`, `bom_v3_legacy_sections.py`).
- Added `tools/ysm_extractor/README.md` with quick usage examples for `ysm_extract.py` and the `ysm_extractor.py` alias.
- Updated `.gitignore` to ignore Python cache artifacts (`**/__pycache__/`, `*.pyc`) and added extractor usage notes in the main README.

This is a practical first pass to make dump -> decode happen in one repo, with no Java behavior changes.

I **will** keep it updated.
